### PR TITLE
fix(law_lookup): exact 꼬리 절단 시 「짚지 못해」 문구 정정

### DIFF
--- a/open_proxy_mcp/services/law_lookup.py
+++ b/open_proxy_mcp/services/law_lookup.py
@@ -1238,6 +1238,12 @@ def build_law_lookup_payload(
         warnings.insert(1, f"강한 매칭이 아니라 **조문 전문을 붙이지 않았습니다** — 아래 {len(results)}건은 "
                            f"어휘가 겹친 참고 후보입니다(전체 {total}건). 전문이 필요하면 조문번호"
                            f"(예: 제542조의8)로 다시 물어보세요.")
+    elif limit_ft is not None and len(results) > limit_ft and ftype is None:
+        # exact 인데 꼬리를 잘랐다 — 「못 찾았다」가 아니라 「찾았고, 약한 꼬리만 표로 남겼다」.
+        #   260902 live 실측: 금산법 §10 을 정확히 짚고도 「딱 맞는 조문을 짚지 못해」라고 말했다.
+        warnings.insert(1, f"강하게 맞는 조문에는 전문을 붙였고(상위 {limit_ft}건), 그 아래 어휘만 겹친 "
+                           f"후보 {len(results) - limit_ft}건은 표에만 있습니다. 전문이 더 필요하면 "
+                           f"조문번호로 다시 물어보세요.")
     elif limit_ft is not None and len(results) > limit_ft:
         warnings.insert(1, f"딱 맞는 조문을 짚지 못해 **전문은 상위 {limit_ft}건만** 붙였습니다 — "
                            f"나머지는 표에만 있습니다. 전문이 더 필요하면 조문번호로 다시 물어보세요.")

--- a/tests/test_law_lookup_expanded.py
+++ b/tests/test_law_lookup_expanded.py
@@ -141,6 +141,9 @@ def test_exact_status_limits_full_text_to_strong_hits_plus_floor():
     assert not any(r.get("full_text") for r in res if r["law"] == "공정거래법"), \
         "글자만 겹친 다른 법 조문에 전문이 붙었다"
     assert d["full_text_suppressed"] is False
+    # 찾아 놓고 「못 찾았다」고 말하지 않는다 (260902 live 실측 문구 오류)
+    assert not any("짚지 못해" in w for w in p["warnings"]), p["warnings"]
+    assert any("표에만" in w for w in p["warnings"]), p["warnings"]
 
 
 def test_exact_status_never_drops_the_strong_hit_full_text():


### PR DESCRIPTION
## Summary

PR #11 배포 뒤 live 실측에서 잡힌 문구 오류 한 줄입니다.

`적기시정조치 요건`이 금산법 §10을 정확히 1위로 짚고 전문도 붙였는데, 경고문은 약한 매칭용 문장(「딱 맞는 조문을 짚지 못해 전문은 상위 3건만」)을 그대로 썼습니다. `limit_ft`를 exact 상태에도 쓰기 시작하면서 문구 분기를 갈라 두지 않은 탓입니다.

exact면 「강하게 맞는 조문에는 전문을 붙였고(상위 3건), 그 아래 어휘만 겹친 후보 N건은 표에만 있습니다」로 말합니다. 약한 매칭 문구는 그대로입니다.

## 검증

- `tests/test_law_lookup_expanded.py`에 문구 검사 2줄 추가
- `uv run pytest -q` 1,429 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tX9Aa9zuF3cM5BwAhSwU6

---
_Generated by [Claude Code](https://claude.ai/code/session_017tX9Aa9zuF3cM5BwAhSwU6)_