### PR TITLE
fix(dividend): 옛 도구명 `dividend` 잔재 정리 + dividend_data 부분 장애 경로 + 카탈로그 ref 검사

### DIFF
--- a/open_proxy_mcp/prompts.py
+++ b/open_proxy_mcp/prompts.py
@@ -32,7 +32,7 @@ def register_all_prompts(mcp) -> None:
             "2. `financial_metrics` — 매출·영업이익·순이익 추세, 차입과 이자보상배율\n"
             "3. `price_multiple_data` — PER·PBR·배당수익률, 그리고 그 값이 어느 기준으로 계산됐는지\n"
             "4. `ownership_structure` — 최대주주와 지분율, 주요 주주 구성\n"
-            "5. `dividend` — 최근 배당 추이와 배당성향\n"
+            "5. `dividend_disclosure` — 최근 배당 추이와 배당성향\n"
             "\n"
             "정리할 때:\n"
             "- 맨 위에 확정된 회사명과 종목코드를 쓴다.\n"

--- a/open_proxy_mcp/services/company.py
+++ b/open_proxy_mcp/services/company.py
@@ -503,8 +503,8 @@ async def build_company_payload(
         warnings=warnings,
         data=payload,
         next_actions=[
-            ("Use company_id or ticker with downstream tools such as shareholder_meeting, ownership_structure, and dividend"
-             if _prefers_english(query, language) else "shareholder_meeting, ownership_structure, dividend 등 후속 data tool에서 company_id 또는 ticker 사용"),
+            ("Use company_id or ticker with downstream tools such as shareholder_meeting_notice, ownership_structure, and dividend_disclosure"
+             if _prefers_english(query, language) else "shareholder_meeting_notice, ownership_structure, dividend_disclosure 등 후속 data tool에서 company_id 또는 ticker 사용"),
         ],
     )
     return envelope.to_dict()

--- a/open_proxy_mcp/services/dividend.py
+++ b/open_proxy_mcp/services/dividend.py
@@ -492,10 +492,15 @@ def _decisions_summary_for_year(
     cash_dps_total = sum(int(d.get("dps_common") or 0) for d in year_decisions)
     cash_dps_pref_total = sum(int(d.get("dps_preferred") or 0) for d in year_decisions)
     total_amount_mil = sum(int((d.get("total_amount") or 0)) for d in year_decisions) // 1_000_000
-    # 🔴 `special_dps`는 배당원장 경로에서 **특별배당분만**을 뜻한다(total_dps = cash + special).
-    # 예전에는 여기서 특별배당이 낀 결의의 주당배당금 **전액**을 더했다 — 삼성전자 FY2020이
-    # 1,578(실제 특별분)이 아니라 1,932(전액)로 나왔다. 비고에서 뽑아낸 특별분만 더한다.
-    # 금액을 못 뽑으면 0이다. 특별배당이 있었다는 사실 자체는 `has_special`이 따로 나른다.
+    # 🔴 `special_dps` 는 **비고에서 뽑아낸 특별배당분만**이다(정보용). 예전에는 특별배당이 낀
+    # 결의의 주당배당금 **전액**을 더했다 — 삼성전자 FY2020이 1,578(실제 특별분)이 아니라
+    # 1,932(전액)로 나왔다. 금액을 못 뽑으면 0이다. 특별배당이 있었다는 사실 자체는
+    # `has_special` 이 따로 나른다.
+    # 🔴 자(尺)가 원장 경로와 다르다 — 결정공시의 「1주당 배당금」은 정기·특별분이 **합산된**
+    # 한 숫자라 여기서는 `cash_dps` 에 특별분이 이미 들어 있고 `total_dps = cash_dps` 다
+    # (삼성전자 FY2020: cash 1,932 · special 1,578). 원장(`alotMatter`) 경로는 특별배당이
+    # 별도 행이라 `total_dps = cash + special` 로 더한다(`dividend_parser.py`). 두 경로의
+    # `cash_dps` 를 나란히 놓으면 특별분만큼 어긋난다 — `source` 칸이 어느 경로인지 말한다.
     special_dps = sum(int(d.get("special_dps_krw") or 0) for d in year_decisions)
 
     fiscal = _fiscal_period_fields(year, end_month)

--- a/open_proxy_mcp/services/dividend_data.py
+++ b/open_proxy_mcp/services/dividend_data.py
@@ -9,7 +9,7 @@
     실제는 84사다(누락 64사, 오탐 0). 원장의 분기 칸은 회사 절반이 비워 두므로 「안 했다」와
     「모른다」를 못 가른다 — 결정공시는 실제로 접수된 건이므로 그 구멍이 없다.
 
-왜 `dividend` 와 따로 두나 — `dividend` 는 회사 하나를 깊게 보는 도구다(실시간 DART 호출,
+왜 `dividend_disclosure` 와 따로 두나 — 그쪽은 회사 하나를 깊게 보는 도구다(실시간 DART 호출,
        미확정 최신분, 정책 신호). 이쪽은 **여럿을 가로로** 본다 — 시계열과 전수 스크리닝.
        같은 표를 쓰지 않으므로 둘의 값이 어긋날 수 있고, 어긋나면 그것이 검산 재료다.
        🔴 **두 소스를 합치지 않는다**(마스터 확정 2026-09-02) — 합치면 검산 수단이 사라진다.
@@ -30,7 +30,8 @@
     🔴 `anomaly='음수차분'` 은 버리지 않고 남긴다 — 분기 발표 뒤 결산에서 배당이 하향된
     사례가 실재한다(계룡건설 2023: 주당 500→400원). 그 행은 「누적」 전제가 깨진 것이다.
   - **0회와 모름의 구분** — `krx_listing`(주간 시세 관측 파생)으로 가른다. 그 사업연도
-    말일 이전에 상장이 확인되면 결의가 없는 해는 `0`, 아직 상장 전이면 `null`이다.
+    말일 이전에 상장이 확인되면 결의가 없는 해는 `0`, 아직 상장 전이거나 티커가 그 표에
+    없어 상장 여부를 모르면 `null`이다. 질의 실패는 `null` 로 메우지 않고 따로 낸다.
     🔴 `krx_listing.first_seen_dd` 는 **관측 시작일이지 상장일이 아니다** — 관측창
     (2015-12-30~)전부터 있던 종목은 `before_window=True`로 표시되고 우리 배당 창
     (2020~)을 통째로 덮으므로 판단엔 지장이 없다.
@@ -99,8 +100,11 @@ def firm_history(corp_code: str, year_from: int, year_to: int) -> dict[str, Any]
         """,
         (corp_code, year_from, year_to),
     )
-    if ann is None and qtr is None:
+    ann_failed, qtr_failed = ann is None, qtr is None
+    if ann_failed and qtr_failed:
         return {"status": "db_error"}
+    # 🔴 한쪽만 실패해도 그 쪽은 「없다」가 아니라 「못 읽었다」다 — 플래그로 나른다.
+    #   (260903 점검: 연간 질의만 실패하면 「원장이 이 구간에 없다」로 렌더되고 있었다.)
 
     # 🔴 **빈 종류 행을 「무배당」으로 보이게 두지 않는다.** DART 서식은 종류주식 칸을
     # 회사가 안 써도 줄 수를 맞춰 내보낸다 — 셀트리온 FY2025 는 「주당 현금배당금」이
@@ -119,6 +123,8 @@ def firm_history(corp_code: str, year_from: int, year_to: int) -> dict[str, Any]
 
     return {
         "status": "ok",
+        "annual_failed": ann_failed,
+        "quarterly_failed": qtr_failed,
         "empty_kind_rows_folded": folded,
         "annual": [
             {"bsns_year": r[0], "stock_kind": r[1], "stock_knd_raw": r[2],
@@ -218,13 +224,16 @@ def payment_counts(corp_code: str, year_from: int, year_to: int) -> dict[str, An
 
 
 def payment_history(pairs: list[tuple[str, str | None]], year_from: int, year_to: int
-                     ) -> dict[str, list[int | None]]:
+                     ) -> dict[str, list[int | None]] | None:
     """(corp_code, stock_code) 목록 → corp_code 별 `[year_from..year_to]` 결정공시 횟수 배열.
 
     한 칸에 세 뜻을 가른다 — **n**(그 해 실제 결의 횟수) · **0**(상장 중인데 결의 없음) ·
-    **null**(그 사업연도 말일 시점에 아직 상장 전이라 모른다). 상장 여부는 `krx_listing`
-    (모듈 docstring의 「0회와 모름의 구분」 참조). 티커가 없거나 `krx_listing` 에 없으면
-    상장 여부를 모르므로 그 회사의 전 구간이 `null` 이다 — 0 으로 메우지 않는다.
+    **null**(상장 여부를 모른다: 그 사업연도 말일 시점에 아직 상장 전이거나, 티커가 없거나
+    `krx_listing` 에 없다). 상장 여부는 `krx_listing`(모듈 docstring의 「0회와 모름의 구분」
+    참조). 모르는 회사는 전 구간이 `null` 이다 — 0 으로 메우지 않는다.
+
+    🔴 **질의 자체가 실패하면 `None`** 을 돌려준다 — 「전 회사가 상장 전」처럼 보이는 null
+    배열로 메우지 않는다(260903 점검). 호출부가 `None` 을 「조회 실패」로 따로 렌더한다.
 
     실측(260903): 3,257종목 전체를 매 호출 스캔하면 279ms — 그래서 `krx_listing` 을
     먼저 구워 두고 여기서는 그 표만 좁혀 읽는다(대상 corp 수만큼, 통상 10ms 대).
@@ -251,7 +260,7 @@ def payment_history(pairs: list[tuple[str, str | None]], year_from: int, year_to
         (year_from, year_to, codes, tickers, codes, codes),
     )
     if rows is None:
-        return {c: [None] * (year_to - year_from + 1) for c in codes}
+        return None
 
     out: dict[str, list[int | None]] = {}
     for corp_code, fy, n, acc_mt, first_seen_dd, before_window in rows:

--- a/open_proxy_mcp/services/value_up.py
+++ b/open_proxy_mcp/services/value_up.py
@@ -108,7 +108,7 @@ _CMP_KO = {"이상": "이상", "초과": "초과", "이하": "이하", "미만":
 _METRIC_CAVEATS: dict[str, str] = {
     "payout_ratio": "배당성향은 「귀속 사업연도」 기준과 「실제 지급 시점」 기준이 다르다. "
                     "회사가 본문에서 「아직 미지급」이라고 밝히는 경우 이 실적값과 어긋난다 — "
-                    "`dividend` 로 지급 여부를 따로 확인해라.",
+                    "`dividend_disclosure` 로 지급 여부를 따로 확인해라.",
     "dividend_yield": "배당수익률은 주가(시세일)와 DPS(사업연도)의 시점이 섞인 값이다.",
     "pbr": "PBR·PER 은 시세 기준일 값이라 사업연도 재무비율과 시점이 다르다.",
     "per": "PBR·PER 은 시세 기준일 값이라 사업연도 재무비율과 시점이 다르다.",
@@ -1114,6 +1114,6 @@ async def build_value_up_payload(
         data=data,
         evidence_refs=_build_value_up_evidence(latest, latest_source, source_type, best_plan_item),
         next_actions=[
-            "commitments scope로 주주환원/ROE 관련 문장 확인" if scope == "summary" else "dividend, ownership_structure와 함께 보면 주주환원 맥락이 더 잘 보인다.",
+            "commitments scope로 주주환원/ROE 관련 문장 확인" if scope == "summary" else "dividend_disclosure, ownership_structure와 함께 보면 주주환원 맥락이 더 잘 보인다.",
         ],
     ).to_dict()

--- a/open_proxy_mcp/tools/company.py
+++ b/open_proxy_mcp/tools/company.py
@@ -186,7 +186,7 @@ def register_tools(mcp):
         when: 검색 시작 → ticker/corp_code 확정 후속 tool에 전달. 최근 공시 종류·빈도 훑을 때.
         rule: 비상장 법인 자동 제외 (상장사 전용). 공식 한글·영문명과 별칭을 우선하고, 부분명은 활성 상장·시총 격차가 충분할 때만 자동 추론. 공식명 exact는 시총보다 우선.
         params: query, max_recent_filings(1-20), start_date/end_date(YYYYMMDD), language(auto|ko|en)
-        ref: shareholder_meeting_notice, ownership_structure, dividend, proxy_contest, value_up
+        ref: shareholder_meeting_notice, ownership_structure, dividend_disclosure, proxy_contest, value_up
         """
         requested_language = (language or "auto").lower()
         if requested_language not in {"auto", "ko", "en"}:

--- a/open_proxy_mcp/tools/dividend_data.py
+++ b/open_proxy_mcp/tools/dividend_data.py
@@ -101,7 +101,8 @@ def _remarks_block(decisions: list[dict[str, Any]], complete: set[int]) -> list[
 
 
 def _history_cell(years: list[int], vals: list[int | None] | None) -> str:
-    """`[4,4,4,4,4]` → `24·23·22·21·20:4·4·4·4·4`. `null`은 `-`(상장 전이라 모름)."""
+    """`[4,4,4,4,4]` → `4·4·4·4·4` (열 머리가 `20·21·22·23·24` 로 같은 순서 — 오름차순).
+    `null` 은 `-`(상장 여부를 모름: 상장 전이거나 관측표에 없음)."""
     if not vals:
         return "-"
     parts = [("-" if v is None else str(v)) for v in vals]
@@ -167,9 +168,13 @@ def _render_firm(name: str, ticker: str, d: dict[str, Any], pay: dict[str, Any])
             L += [f"> 종류주식 칸이 비어 있는 줄 {_folded}개는 접었다 — DART 서식이 회사가 "
                   "안 쓴 종류 칸도 줄 수를 맞춰 내보내는 것이라, 그대로 두면 「같은 해에 "
                   "배당했는데 무배당」으로 읽힌다. **무배당 판정이 아니다.**"]
+    elif d.get("annual_failed"):
+        # 🔴 연간 질의만 실패한 것 — 「원장에 없다」가 아니라 **못 읽었다**다(260903 점검).
+        L += ["", "> 🔴 **연간 원장을 읽지 못했다 (조회 실패).** 「이 표에 없다」도 「배당이 없다」도 "
+              "아니라 **모른다**이다 — 잠시 뒤 다시 시도하거나 `dividend_disclosure` 로 실시간 확인하라."]
     else:
         L += ["", "> 이 회사의 연간 확정 배당 원장이 이 구간에 없다. "
-              "「배당이 없다」가 아니라 「이 표에 없다」이다 — `dividend` 로 실시간 확인하라."]
+              "「배당이 없다」가 아니라 「이 표에 없다」이다 — `dividend_disclosure` 로 실시간 확인하라."]
 
     qtr = [q for q in (d.get("quarterly") or []) if q.get("row_status") == "확정"]
     if qtr:
@@ -185,6 +190,8 @@ def _render_firm(name: str, ticker: str, d: dict[str, Any], pay: dict[str, Any])
             L += ["", "> 🔴 `음수차분` 이 붙은 줄은 **누적이라는 전제가 깨진 구간**이다. "
                   "분기 발표 뒤 결산에서 배당이 하향된 사례가 실재한다 — 그 줄은 신뢰를 낮게 "
                   "잡고 `evidence` 로 원문을 확인하라."]
+    elif d.get("quarterly_failed"):
+        L += ["", "> 🔴 **분기 원장을 읽지 못했다 (조회 실패).** 「분기 확정 없음」이 아니라 **모른다**이다."]
     else:
         n_all = len(d.get("quarterly") or [])
         L += ["", f"> 원장 분기 확정 없음 (그 구간 {n_all}칸 모두 미산출·무배당·보고서없음). "
@@ -194,13 +201,23 @@ def _render_firm(name: str, ticker: str, d: dict[str, Any], pay: dict[str, Any])
 
 # ──────────────────────────────────────────────────────────────── screen ──
 def _render_screen(year: int, cond: list[str], d: dict[str, Any], limit: int,
-                    hist_years: list[int], hist: dict[str, list[int | None]]) -> str:
+                    hist_years: list[int], hist: dict[str, list[int | None]] | None) -> str:
+    """`hist=None` 은 이력열 **조회 실패**다(빈 dict 는 「셀 회사가 없다」) — 둘을 가른다."""
     rows = d.get("rows") or []
-    matched = d.get("matched", len(rows))
-    head = f"**조건에 걸린 회사 {matched}사** (모집단 {d.get('n_universe')}사 중"
-    if len(rows) < matched:
-        head += f" · 아래에는 상위 {len(rows)}사만 실었다. 전부 보려면 `limit`을 올린다"
-    head += ")"
+    matched = d.get("matched")
+    n_uni = d.get("n_universe")
+    uni = f"모집단 {n_uni}사" if n_uni is not None else "모집단 조회 실패"
+    # 🔴 매칭 수·모집단 질의만 실패해도 예외로 죽거나 「None사」를 찍지 않는다 — 실은 행은
+    #   실은 행대로 내고, 못 센 것은 못 셌다고 말한다(260903 점검: `len(rows) < None` 이
+    #   TypeError 였다). 실은 수를 매칭 수로 읽히게 두지도 않는다.
+    if matched is None:
+        head = (f"**조건에 걸린 회사 수를 세지 못했다 (조회 실패)** — 아래 {len(rows)}사는 실은 "
+                f"것일 뿐 전체 매칭 수가 아니다 ({uni})")
+    else:
+        head = f"**조건에 걸린 회사 {matched}사** ({uni} 중"
+        if len(rows) < matched:
+            head += f" · 아래에는 상위 {len(rows)}사만 실었다. 전부 보려면 `limit`을 올린다"
+        head += ")"
     hist_label = "·".join(str(y - 2000) for y in hist_years) if hist_years else ""
     L = [f"## 배당 스크리닝 — FY{year}", "",
          f"_조건: {' · '.join(cond) if cond else '없음(배당 확정 전체)'}_",
@@ -220,17 +237,21 @@ def _render_screen(year: int, cond: list[str], d: dict[str, Any], limit: int,
          f"| 회사 | 종목코드 | DPS | 배당총액(신고) | 배당성향 | 결정공시 이력({hist_label}) | 공시번호 |",
          "|---|---|---|---|---|---|---|"]
     for r in rows:
-        cell = _history_cell(hist_years, hist.get(r["corp_code"]))
+        cell = "?" if hist is None else _history_cell(hist_years, hist.get(r["corp_code"]))
         L.append(f"| {r['name']} | `{r['ticker']}` | {_num(r.get('dps_krw'), '원', '{:,.0f}')} | "
                  f"{_won_short(r.get('div_total_krw'))} | {_num(r.get('payout_pct'), '%')} | "
                  f"{cell} | `{r.get('rcept_no') or '-'}` |")
-    if not rows:
+    if not rows and matched is not None:
         L += ["", "> 조건에 맞는 회사가 없다. 조건을 넓히거나 사업연도를 바꿔 보라. "
               "**「그런 회사가 없다」이지 「조회가 실패했다」가 아니다.**"]
-    L += ["", "> 이력열의 `-` 는 그 사업연도 말일 시점에 **아직 상장 전**이라 모른다는 뜻이다 "
-          "(0회로 읽지 말 것). `0` 은 상장 중인데 실제로 결의가 없었다는 뜻이다.",
+    if hist is None:
+        L += ["", "> 🔴 **결정공시 이력열을 읽지 못했다 (조회 실패).** `?` 는 「결의 없음」도 "
+              "「상장 전」도 아니라 **모른다**이다 — 잠시 뒤 다시 시도하라."]
+    L += ["", "> 이력열의 `-` 는 **상장 여부를 모른다**는 뜻이다 — 그 사업연도 말일 시점에 아직 "
+          "상장 전이거나, 티커가 상장 관측표(`krx_listing`)에 없다. 0회로 읽지 말 것. "
+          "`0` 은 상장 중인데 실제로 결의가 없었다는 뜻이다.",
           "> 총액은 **신고총액** 하나만 낸다 — 보통/우선 배분값은 종류별 발행주식수가 "
-          "없어 검산에 실패해 내지 않는다. 회사 하나를 깊게 보려면 `dividend`."]
+          "없어 검산에 실패해 내지 않는다. 회사 하나를 깊게 보려면 `dividend_disclosure`."]
     return "\n".join(L)
 
 
@@ -269,11 +290,11 @@ def register_tools(mcp):
         format: str = "md",
     ) -> str:
         """desc: 확정 배당 — 회사 시계열 / 조건 스크리닝 / 시장·섹터 집계. DART 정기보고서(alotMatter) 전수 수집본(코스피 828사 × 2020~2025)과 결정공시 집계(FY2020~2024)를 DB 에서 읽는다. DART 를 실시간 호출하지 않는다.
-        when: 여러 해를 가로로 보거나(firm) · 조건으로 회사를 거르거나(screen) · 시장·섹터를 볼 때(market/sector). 회사 하나를 깊게(정책신호·최신 미확정분·실시간 원문)는 `dividend`. 시총가중 배당수익률·forward DPS·DY 는 `price_multiple_data`/`forward_estimates_data`.
+        when: 여러 해를 가로로 보거나(firm) · 조건으로 회사를 거르거나(screen) · 시장·섹터를 볼 때(market/sector). 회사 하나를 깊게(정책신호·최신 미확정분·실시간 원문)는 `dividend_disclosure`. 시총가중 배당수익률·forward DPS·DY 는 `price_multiple_data`/`forward_estimates_data`.
         scope: `firm` 회사 하나(company 필요, 시계열+결정공시 횟수+**결의별 비고 원문 전문**) / `screen` 조건으로 거르기(bsns_year) / `market` 코스피 전체 / `sector` WICS 섹터(sector 필요)
         rule: 금액(DPS·총액·배당성향)은 원장 `alotMatter` 확정치, **횟수**(min_payments·이력열)는 결정공시 원문 — 서로 다른 소스라 합치지 않는다. 결정공시는 FY2020~2024 만 온전(그 밖은 `scope_incomplete`). 총액은 신고총액 하나만(보통/우선 배분 불가). 비고(11번 「기타 투자판단과 관련한 중요사항」)는 **결의마다 전문을 그대로** 낸다 — 특별·기념배당, 감액배당 재원, 자기주식 제외 산정, 주총 갈음, 차등배당은 그 칸에만 적힌다. 파생 플래그는 힌트일 뿐이니 **원문을 읽고 판단하라.**
         min_payments: screen 전용. **그 해에 실제로 결의된 배당 횟수**가 이 값 이상인 회사(결정공시 기준 — 원장 분기 빈칸 추정이 아니다). `quarterly_only=True` 는 `min_payments=2` 의 별칭(하위호환).
-        ref: dividend, price_multiple_data, forward_estimates_data, screener, evidence
+        ref: dividend_disclosure, price_multiple_data, forward_estimates_data, screener, evidence
         """
         rng = dd.year_range()
         if rng is None:
@@ -341,11 +362,13 @@ def register_tools(mcp):
             complete = dd.payment_scope_years()
             hist_years = list(range(min(complete), max(complete) + 1)) if complete else []
             pairs = [(r["corp_code"], r["ticker"]) for r in (data.get("rows") or [])]
+            # None = 이력 질의 실패(렌더가 「모른다」로 낸다) · {} = 셀 회사가 없다.
             hist = dd.payment_history(pairs, hist_years[0], hist_years[-1]) if pairs and hist_years else {}
 
             if format == "json":
                 return as_pretty_json({"status": "ok", "data": data, "conditions": cond,
                                        "bsns_year": year, "payment_history": hist,
+                                       "payment_history_failed": hist is None,
                                        "payment_history_years": hist_years})
             return _render_screen(year, cond, data, lim, hist_years, hist)
 

--- a/open_proxy_mcp/tools/financial_metrics.py
+++ b/open_proxy_mcp/tools/financial_metrics.py
@@ -549,7 +549,7 @@ def register_tools(mcp):
         rule: source = fnlttSinglAcnt(BS+IS 30행, 요청 fs_div로 행 필터) + fnlttSinglIndx(보조 ROE) + fnlttSinglAcntAll(CF+213행) + accnutAdtorNmNdAdtOpinion(감사의견 3년). 금액 raw KRW int(_krw), %는 float(_pct), 비율 decimal(_ratio). 연결 default, 적자/0 분모 graceful. 금융사(은행·지주)는 매출액 계정이 없어 None — 영업이익·순이익 기준 해석. 분기 합≠연간이면 기중 분할·재작성 warning 자동 부착. 이자보상배율 분모 = IS 이자비용, 없으면 CF '이자의 지급' (금융비용 총액 사용 안 함). EBITDA는 CF에서 D&A가 추출된 회사만 산출 (조정 합계 공시 회사는 None). 사업연도 라벨에는 그 연도가 덮는 12개월과 결산월을 붙인다(6월 결산 오독 방지). 근거 정기보고서가 정정본이면 정정일과 함께 명시. accruals_gap은 비율(`_pct`)과 금액차(`accruals_gap_krw`)를 같이 내고, 영업이익이 적자·초박막이면 `accruals_gap_reliability`로 비율 왜곡을 표시(alert도 `accruals_red` 대신 `accruals_ratio_unreliable`).
         period: DART 기간 의미가 항목별로 다름 — 손익 thstrm=당기3개월/누적은 thstrm_add, 현금흐름=누적, 재무상태=잔액. summary가 분기보고서면 ① 손익은 누적(YTD) 기준 primary + 당기 분기(standalone)를 `standalone`에 별도 동봉(반기/3분기), ② 회전일수(DSO/DIO/CCC)는 TTM(최근 4분기) 분모로 산출(단일분기 연환산 왜곡 제거), ③ ROE/ROA/자산회전율은 연환산 안 함(분기값). 기준은 항상 `period_basis`/`turnover_basis`/`basis_note`로 명시. year 미지정 시 quarterly·qoq는 당해 연도(최신 분기 포함), summary·yearly·yoy는 직전 사업연도.
         scope: `summary` 핵심 지표 1년(분기보고서면 누적+standalone) / `yearly` N년 추이 / `quarterly` 12분기 standalone 손익 + QoQ·YoY(마진은 %p) 기본 동봉 (Q4는 연간−3분기 누적 차분 — 연간치 혼입 없음) / `yoy` 전년+alert / `qoq` 전분기 (standalone 기준) / `audit_opinion` 3년 추이
-        ref: dividend, corp_gov_report, shareholder_meeting_notice, evidence
+        ref: dividend_disclosure, corp_gov_report, shareholder_meeting_notice, evidence
         """
         payload = await build_financial_metrics_payload(
             company,

--- a/open_proxy_mcp/tools/forward_estimates_data.py
+++ b/open_proxy_mcp/tools/forward_estimates_data.py
@@ -119,11 +119,11 @@ def register_tools(mcp):
                                      period_type: str = "FY", actual_years: int = 2,
                                      format: str = "md") -> str:
         """desc: 컨센서스 **포워드 추정치**(내년·내후년 예상 매출·영업이익·EPS·PER/PBR/PSR·성장률) + 대조용 최근 실적. 애널리스트 추정 스냅샷(`fwd`) 기반 — DART 공시가 아니다.
-        when: "삼성전자 내년 예상 PER"·"2027년 컨센서스 영업이익"·"내년 실적 전망"·"포워드 밸류에이션"·"추정 EPS 성장률". 확정 실적 기반 현재 배수는 `price_multiple_data`(scope=firm), 재무 원본은 `financial_metrics`, 배당 상세는 `dividend`.
+        when: "삼성전자 내년 예상 PER"·"2027년 컨센서스 영업이익"·"내년 실적 전망"·"포워드 밸류에이션"·"추정 EPS 성장률". 확정 실적 기반 현재 배수는 `price_multiple_data`(scope=firm), 재무 원본은 `financial_metrics`, 배당 상세는 `dividend_disclosure`.
         rule: **자(尺)를 두 겹으로 싣는다** — 봉투 `ruler`(as_of·**price_dd**·단위·PER 정의·배수 범위)에 한 번, 행마다 또(`period`·`row_kind`·`basis`). 🔴 `as_of` 와 `price_dd` 는 다르다(주말·휴일) — 배수는 **price_dd 종가** 기준이므로 "as_of 기준 PER"이라고 쓰면 틀린다. 행은 실적/추정이 아니라 **`reported`(벤더 원천, 틀리면 벤더 책임) / `derived`(우리 계산, 검산 대상)** 로 가른다 — 성장률이 실적/추정 경계를 넘나들기 때문. **PER=보통주 시총÷지배주주순이익**으로 `price_multiple_data` 와 정의를 맞췄다(벤더 원본은 주가÷EPS인데 그 식은 260823 에 하우스에서 버렸다 — 액면분할 때 옛 주식수 EPS 와 새 주가가 섞인다). 10% 이상 갈리면 경고로 밝힌다. **배수는 추정 FY·최신 확정 FY 행에만** 둔다(오늘 주가÷과거 실적은 배수가 아니다). **금액은 전부 원(KRW) 정수** — 억원 안 쓴다. 빈칸은 채우지 않고 뺀다(0 아님·자료 없음). bundle=core(기본, 좁게) / growth(성장률·전기값·PEG) / quality(수익성·재무비율) / keys(내부키·회계연도) / all — 기본이 정답이 아니라 크기 때문에 자른 것이니 필요하면 넓혀 부를 것. period_type=FY(기본)/Q/all · actual_years=대조용 실적 행 수(기본 2 — 직전 확정 실적 2개년. 추세를 보려면 넓혀 부를 것).
         status: ok / **no_estimates**(그 종목은 애널리스트 미커버 — 전체 2,764종목 중 추정 보유 713종목뿐, 74%가 여기 해당. 자료 없음이지 오류 아님) / not_found(그런 종목 없음·오탈자·비상장) / unlisted / ambiguous(동명 후보표) / **db_error**(DB 장애 — 자료 없음과 다르다, 재시도) / invalid. 🔴 셋을 뭉뚱그리지 말 것: no_estimates는 다른 도구로, not_found는 이름 재확인, db_error는 재시도.
 
-        ref: price_multiple_data, financial_metrics, dividend, company
+        ref: price_multiple_data, financial_metrics, dividend_disclosure, company
         """
         payload = await build_forward_estimates_payload(
             company=company, bundle=bundle, period_type=period_type,

--- a/open_proxy_mcp/tools/price_multiple_data.py
+++ b/open_proxy_mcp/tools/price_multiple_data.py
@@ -236,7 +236,7 @@ _METHODOLOGY = """# price_multiple_data 방법론·기준·출처 (수치 근거
 ## 산출 범위 — 이 셋뿐입니다
 PER · PBR · 배당수익률. RIM·EV/EBITDA·PSR·FCF·5년밴드·PIT 시계열·주당 수정주가 시계열은
 **만들지 않습니다**(260823, 종전의 「v1.1 예정」 표기를 걷어냄). 현금흐름·FCF·듀퐁은
-`financial_metrics`, 배당 상세는 `dividend` 를 쓰세요.
+`financial_metrics`, 배당 상세는 `dividend_disclosure` 를 쓰세요.
 
 ## 판단 기준 (게이팅)
 - **N/M**: 지배순이익·지배자본 ≤0(적자·자본잠식) 또는 완전자본잠식 → 배수 미산출(음수 PER 금지)
@@ -344,11 +344,11 @@ def register_tools(mcp):
     async def price_multiple_data(company: str = "", scope: str = "firm", format: str = "md",
                         scheme: str = "wics_industry") -> str:
         """desc: 상대가치 밸류에이션 — 기업 심층(PER·PBR·배당수익률) + 시장 전체·산업별·종목 히스토리(주간 스냅샷). 한국 표준(연결, 지배주주 귀속). 비KRW 기능통화 자동 KRW 환산(ECOS), 스케일가드, N/M 게이팅.
-        when: "PER/PBR 얼마"·"싼가 비싼가"(scope=firm) / "코스피·코스닥 전체 밸류"(market) / "업종별 PER·PBR"·"섹터 대비 어디"(sector, company 지정 시 소속 섹터 비교) / "밸류 추이"(firm_history) / **"이 수치 근거·계산 과정이 뭐야?"(explain — company 지정 시 실제 값 대입 계산, 미지정 시 방법론·기준·출처 전문)**. 재무 펀더멘탈 자체는 financial_metrics, 배당 상세는 dividend.
+        when: "PER/PBR 얼마"·"싼가 비싼가"(scope=firm) / "코스피·코스닥 전체 밸류"(market) / "업종별 PER·PBR"·"섹터 대비 어디"(sector, company 지정 시 소속 섹터 비교) / "밸류 추이"(firm_history) / **"이 수치 근거·계산 과정이 뭐야?"(explain — company 지정 시 실제 값 대입 계산, 미지정 시 방법론·기준·출처 전문)**. 재무 펀더멘탈 자체는 financial_metrics, 배당 상세는 dividend_disclosure.
         rule: scope=firm(기본, company 필수) = 실시간 DART 재무 × krx_weekly 시세 — **PER=보통주 시총÷지배순이익 · PBR=보통주 시총÷지배자본(MRQ)** (260823 전환: 주가÷EPS 는 액면분할·병합 때 옛 주식수 기준 EPS 와 새 주가가 섞여 틀렸다). 주식수가 상쇄돼 조정성 이벤트에 불변이고 **스냅샷 스코프와 정의가 같다**. EPS(공시 기본주당이익)·BPS 는 회사 공식값이라 인풋으로 함께 싣되 배수 산출엔 안 쓴다. 대가 — 가중평균이 아니고(연중 유상증자 시 공시 EPS 와 벌어짐), 분자는 보통주 시총인데 분모엔 우선주 몫이 포함돼 소폭 하향 편향. 분모≤0·완전자본잠식=N/M. scope=market/sector/firm_history = Supabase 주간 스냅샷(opm_val_market·opm_val_market·opm_val_firm, market_val_weekly 배치가 갱신) — PER=**Σ보통주 시총**÷Σ지배순이익(시총가중 조화평균, 우선주 시총은 제외·cap_pref 별도 노출), 시총 기반이라 수정주가 조정 불변. 섹터 분류=KSIC 하이브리드. firm과 스냅샷 방법론 차이(보통주 주가 vs 총시총) 有 — 각 출력에 명시. 값 raw KRW int(_krw), % float(_pct). **scope=market 과 scope=sector(scheme=wics_sector) 에는 시총가중 배당수익률이 함께 실린다**(260831) — 확정=div_yield_hist(사업연도 12월결산 확정 DPS, 연 1회) · 선행=fwd_agg(애널리스트 추정 DPS). PER·PBR 과 **출처 표도 기준일도 모집단도 다르다.** 분모 두 벌(all=무배당 포함 시장 관행값 / payers=배당주만)을 나란히 내는데, 코스닥은 두 값이 두 배 차이라 반드시 같이 읽어야 한다 — 눌림의 절반은 배당력이 아니라 배당하는 회사가 적다는 구성 차이다. PER 과 달리 적자여도 배당이 있으면 값이 난다. scheme=ksic·wics_industry 에는 안 붙는다(집계 버킷이 WICS 대분류다).
         status: ok / invalid / not_found(우선주는 보통주 코드로) / unlisted / no_financials / no_data(배치 미실행).
        
-        ref: financial_metrics, dividend, corp_gov_report, evidence
+        ref: financial_metrics, dividend_disclosure, corp_gov_report, evidence
         """
         sc = (scope or "firm").strip().lower()
         if sc in ("explain", "method", "basis"):  # 수치 근거 — 계산 과정·기준·출처 (유저 "근거가 뭐야?")

--- a/open_proxy_mcp/tools/screener.py
+++ b/open_proxy_mcp/tools/screener.py
@@ -264,14 +264,14 @@ def register_tools(mcp):
         format: str = "md",
     ) -> str:
         """desc: **전체시장 공시 스크리너 / 아침 공시 디제스트.** 직전 실행 이후~오늘 전종목에 뜬 주요 공시를 카드형으로 요약(기업명+시총+유형+단계+정정+DART/naver 링크). 무인자 호출=오늘 아침 디제스트. scan(무엇이 떴나, 싸게)=디폴트, details=true면 필요 건만 문서 열어 유형별 핵심숫자(금액·분모%·DPS·안건·지분%).
-        when: "오늘/어제 무슨 공시 떴어", "최근 며칠/일주일 잠정실적 발표", 매일 아침 공시 브리핑, 전체시장 **영업(잠정)실적**·수주·자사주·배당·증자·주총·5%보유 훑기, 특정 유형만 필터, 시총상위/지정종목만. 특정 회사 1곳 심층은 개별 tool(provisional_earnings·order_contracts·dividend 등).
+        when: "오늘/어제 무슨 공시 떴어", "최근 며칠/일주일 잠정실적 발표", 매일 아침 공시 브리핑, 전체시장 **영업(잠정)실적**·수주·자사주·배당·증자·주총·5%보유 훑기, 특정 유형만 필터, 시총상위/지정종목만. 특정 회사 1곳 심층은 개별 tool(provisional_earnings·order_contracts·dividend_disclosure 등).
         types: `core`(**영업잠정실적**·수주·자사주·배당·증자CB·주총소집·5%보유) / `all` / **사람 말 쉼표구분** — "자사주, 배당", "수주", "실적", "주총", "지분", "합병", "소송", "증자" 등. 코드도 그대로: earnings(잠정실적: 회계연도·기간·매출·영업익),order,treasury,dividend,dilutive,agm_notice,ownership5,agm_result,restructuring,stake_deal,control_change,litigation,insider10.
         period: **사람 말로 받는다** — "오늘"/"어제"/"어제부터"/"지난주"/"최근 7일"/"지난 한 달"/"최근 3개월"/"최근 45일", 날짜범위 "20260801~20260820"·"2026-08-01~2026-08-20", 단일일 "20260820". 또는 `start_date`/`end_date`(레포 공통 인자, YYYYMMDD). 옛 코드(today/yesterday/since_yesterday/last_7d/last_30d/custom+custom_start·custom_end)도 그대로 동작. 디폴트 since_yesterday. 시장스캔 3개월 하드캡.
         universe: **사람 말로 받는다** — "전체"(디폴트) / "코스피"·"코스닥"(시장 전체) / "코스피200" / "코스피 시총 상위 30"·"코스닥 상위 50"·"시총 상위 100" / "삼성전자, SK하이닉스"(이름 나열, 자동 코드화). 옛 문법(all·kospi200·kospi:N·kosdaq:N·top_mktcap:N·market:kospi|kosdaq·custom:…)도 그대로 동작. 각 카드에 시총 병기.
         details: false(디폴트, scan만) / true(문서 열어 숫자 — **이번 페이지 건만** 연다. 기간>30일이면 자동 off, 기간>7일이면 preview. 유니버스 크기로는 더 이상 막지 않는다).
         offset: 이어받기 위치(디폴트 0). 응답의 `paging.next_offset` 을 그대로 넣으면 다음 묶음이 온다. **매칭 수(`paging.matched`)와 이번에 실은 수(`paging.returned`)는 다른 값이다** — 표시된 건수를 전체로 읽지 말 것.
         rule: DART list.json 전체시장 필러(corp_code 無)를 유형별 detail코드로 스캔 → report_nm 키워드 분류 → 시총(krx_weekly) 부착 → dedup(정정=최신본만). 정정=`[기재정정]` 프리픽스, 단계태깅(결정≠결과≠소각). details는 유형별 파서(order_contracts 등) 디스패치. 빈 결과는 no_new(신규없음)/status=error(조회실패)로 구분.
-        ref: order_contracts·treasury_share·dividend·dilutive_issuance·shareholder_meeting_notice·ownership_structure (유형별 심층)
+        ref: order_contracts·treasury_share·dividend_disclosure·dilutive_issuance·shareholder_meeting_notice·ownership_structure (유형별 심층)
         """
         payload = await build_screener_payload(
             types=types, period=period, universe=universe, details=details,

--- a/open_proxy_mcp/tools/shareholder_commitment.py
+++ b/open_proxy_mcp/tools/shareholder_commitment.py
@@ -134,11 +134,11 @@ def register_tools(mcp):
         계획을 실제로 지켰나"를 본다. 자사주 소각 사이클마다 매입시점 BPS 대비 실제 매입가를 비교해
         장부가(BPS) 기준 손익을 원화로 계산(내재가치 판단은 하지 않음, 장부가 사실만).
         when: 스튜어드십/기관투자자 engagement, 연례 보유종목 점검, "이 회사 약속 지켰나" 질문.
-        rule: value_up(계획)+corp_gov_report(준수변화)+dividend(실제배당)+treasury_share(실제소각,
+        rule: value_up(계획)+corp_gov_report(준수변화)+dividend_disclosure(실제배당)+treasury_share(실제소각,
         260707 원문단위버그 수정 완료)를 조합. 결정↔실행 매칭 오탐 의심 사이클은 sanity 필터로
         제외하고 data_quality_flags에 남김(알려진 treasury_share `_link_cycles` 별개 이슈 대응).
         lookback_years: 조회 기간(년), 기본 3
-        ref: value_up, corp_gov_report, dividend, treasury_share
+        ref: value_up, corp_gov_report, dividend_disclosure, treasury_share
         """
         payload = await build_shareholder_commitment_payload(company, lookback_years=lookback_years)
         if format == "json":

--- a/open_proxy_mcp/tools/shareholder_meeting_results.py
+++ b/open_proxy_mcp/tools/shareholder_meeting_results.py
@@ -24,10 +24,10 @@ def register_tools(mcp):
         format: str = "md",
     ) -> str:
         """desc: 주주총회 **의결 결과** (사후). 안건별 가결/부결 + 찬반율. DART API 우선, KIND fallback.
-        when: 주총 종료 후 실제 의결 결과 확인. 사전 안건은 `shareholder_meeting_notice`. 후속 공시(배당/자사주/구조)는 dividend·treasury_share 등 각 tool 직접 호출.
+        when: 주총 종료 후 실제 의결 결과 확인. 사전 안건은 `shareholder_meeting_notice`. 후속 공시(배당/자사주/구조)는 dividend_disclosure·treasury_share 등 각 tool 직접 호출.
         rule: rcept_no 80 prefix (수시공시) 본문 fetch. 결과 미공시(KIND 노출 지연) 시 status=pending_or_missing.
         meeting_type: `auto` / `annual` / `extraordinary`
-        ref: shareholder_meeting_notice, dividend, treasury_share, proxy_contest, evidence
+        ref: shareholder_meeting_notice, dividend_disclosure, treasury_share, proxy_contest, evidence
         """
         payload = await build_shareholder_meeting_payload(
             company,

--- a/open_proxy_mcp/tools/treasury_share.py
+++ b/open_proxy_mcp/tools/treasury_share.py
@@ -227,7 +227,7 @@ def register_tools(mcp):
         when: 자사주 취득·처분·소각·신탁 이력·규모. 결정↔결과 사이클 매칭으로 집행 검증.
         rule: 9 source 병렬 — Decisions: tsstkAqDecsn(취득)/tsstkDpDecsn(처분)/tsstkAqTrctrCnsDecsn(신탁체결)/tsstkAqTrctrCcDecsn(신탁해지)/소각결정. Executions: 취득결과/처분결과/신탁취득상황/신탁해지결과 보고서. ACODE 본문 파싱. 사이클 매칭은 "주요사항보고서 제출일" / "신탁계약 체결일" ↔ decision rcept_dt. 종류별: 보통주 vs 종류주식(우선주·기타주식·RCPS 등 통합) — 결정/결과 모두 amount_common_krw/amount_preferred_krw로 분리(결과는 복수 종류 시 ACODE가 보통주만 잡는 것을 일별 합산 보정).
         scope: `summary` 모든 events + breakdown + cycle 매칭 / `annual` 사업보고서 연간 누적 잔고
-        ref: value_up, ownership_structure, dividend, evidence
+        ref: value_up, ownership_structure, dividend_disclosure, evidence
         """
         payload = await build_treasury_share_payload(
             company,

--- a/open_proxy_mcp/tools/value_up.py
+++ b/open_proxy_mcp/tools/value_up.py
@@ -231,7 +231,7 @@ def register_tools(mcp):
         format: str = "md",
     ) -> str:
         """desc: 기업가치제고계획(밸류업) 공시 + commitment 문장. 주주환원 **정책·미래 약속**. 자사주 소각 이행 교차참조 포함.
-        when: 밸류업 계획, ROE/PBR/배당성향 목표, 자사주 소각 계획 등 미래 약속. 실제 배당은 `dividend`, 자사주 사실은 `treasury_share`.
+        when: 밸류업 계획, ROE/PBR/배당성향 목표, 자사주 소각 계획 등 미래 약속. 실제 배당은 `dividend_disclosure`, 자사주 사실은 `treasury_share`.
         rule: DART I 밸류업 키워드 → 없으면 KIND 0184 fallback. 공시 카테고리: plan/progress/meta_amendment(고배당기업 재공시). 최신이 meta_amendment면 실계획 본문을 latest_plan으로 별도. summary/commitments에 24개월 자사주 이벤트 treasury_cross_ref 포함.
         scope: `summary` / `plan` 원문 발췌 / `commitments` 핵심 약속 + **수치 목표↔실적 대조표** + 이행 교차참조 / `timeline` 공시 이력
         commitments: 「목표 대비 어디까지 왔나」는 여기서 본다. `numeric_targets` 는 회사 원문에서 뽑은
@@ -243,7 +243,7 @@ def register_tools(mcp):
           `numeric_targets_unparsed` 는 **지표는 언급됐는데 수치를 못 읽은 자리**이며 원문 조각이 담겨 있다 —
           「목표가 없다」로 읽지 마라. 표에 없는 약속(자사주 소각·IR 확대 등 비수치 약속)은
           `highlights`(원문 문장)에 그대로 있으니 표만 보고 결론내지 마라.
-        ref: dividend, treasury_share, ownership_structure, financial_metrics, price_multiple_data, company, evidence
+        ref: dividend_disclosure, treasury_share, ownership_structure, financial_metrics, price_multiple_data, company, evidence
         """
         payload = await build_value_up_payload(
             company,

--- a/scripts/check_tool_catalog.py
+++ b/scripts/check_tool_catalog.py
@@ -32,8 +32,47 @@ SUPPORT_PAGES = {
 }
 
 
+def _description_problems(tools, runtime_tools: set[str]) -> list[str]:
+    """도구 설명이 **없는 도구**를 가리키면 실패한다.
+
+    260903: 260902 에 `dividend` 가 `dividend_disclosure` 로 개명된 뒤 도구 설명의 `ref:`·`when:`
+    16곳이 옛 이름으로 남아 있었는데, 페이지·링크만 보던 이 스크립트는 통과시켰다. 읽는 쪽이
+    LLM 이라 없는 도구명을 그대로 호출한다. 두 가지를 본다 —
+      · `ref:` 줄의 도구명 토큰(밑줄이 든 식별자, 또는 은퇴한 이름)은 런타임에 있어야 한다
+        (괄호 주석 제외). `evidence` 의 「모든 data/action tool」 같은 산문 낱말은 안 본다.
+      · 은퇴한 이름(`usage_tracker.TOOL_ALIASES` 의 키)이 백틱 안이나 `ref:`·`when:` 줄에
+        단어로 서 있으면 안 된다. `types:` 같은 코드 목록(`screener` 의 유형 코드 `dividend`)은
+        도구명이 아니라 여기서 보지 않는다.
+    """
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from usage_tracker import TOOL_ALIASES
+    retired = set(TOOL_ALIASES)
+    problems: list[str] = []
+    for tool in tools:
+        desc = tool.description or ""
+        for name in retired:
+            if re.search(rf"`{name}`", desc):
+                problems.append(f"{tool.name} 설명에 은퇴한 도구명 `{name}` (→ {TOOL_ALIASES[name]})")
+        for line in desc.splitlines():
+            s = line.strip()
+            if not s.startswith(("ref:", "when:")):
+                continue
+            body = re.sub(r"\([^)]*\)", " ", s.split(":", 1)[1])
+            tokens = set(re.findall(r"(?<![a-z0-9_`])[a-z][a-z0-9_]+(?![a-z0-9_`])", body))
+            if s.startswith("ref:"):
+                # 도구명처럼 생긴 토큰(밑줄 포함)과 은퇴한 이름만 본다 — `evidence` 의
+                #   「모든 data/action tool」 같은 산문은 도구명이 아니다.
+                for tok in sorted(tokens - runtime_tools):
+                    if tok in retired or "_" in tok:
+                        problems.append(f"{tool.name} ref: 런타임에 없는 도구 {tok}")
+            for tok in sorted(tokens & retired):
+                problems.append(f"{tool.name} {s[:4]} 줄에 은퇴한 도구명 {tok} (→ {TOOL_ALIASES[tok]})")
+    return problems
+
+
 def main() -> int:
-    runtime_tools = {tool.name for tool in asyncio.run(build_mcp().list_tools())}
+    tools = asyncio.run(build_mcp().list_tools())
+    runtime_tools = {tool.name for tool in tools}
     documented_tools = {
         path.stem
         for path in CATALOG_DIR.glob("*.md")
@@ -46,6 +85,7 @@ def main() -> int:
         problems.append("Missing wiki tool pages: " + ", ".join(missing_docs))
     if stale_docs:
         problems.append("Wiki pages without runtime tools: " + ", ".join(stale_docs))
+    problems += _description_problems(tools, runtime_tools)
 
     # 페이지 존재만 봐서는 부족했다 (260817): proxy_guideline 은 페이지가 있는데도
     # README 의 「도구 한눈에」 표에 없어 사람이 읽는 목록에서만 빠져 있었고,

--- a/tests/test_dividend_data_failure_paths.py
+++ b/tests/test_dividend_data_failure_paths.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+"""dividend_data — 질의 **하나만** 실패하는 부분 장애를 「없다」나 예외로 내지 않는다 (260903 점검).
+
+`tests/test_dividend_raw_cells.py` 가 「결정공시 집계 전체 실패 → 모른다」를 잠갔다면,
+여기서는 그 옆 구멍들이다 — 매칭 수 COUNT 만 실패하면 `len(rows) < None` 으로 도구가
+죽었고, 연간 원장만 실패하면 「원장이 이 구간에 없다」, 이력열만 실패하면 전 회사가
+「상장 전」(`-`)으로 읽혔다. network 0콜 · DB 0콜(전부 monkeypatch).
+"""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+from open_proxy_mcp.services import dividend_data as dd
+from open_proxy_mcp.tools import dividend_data as dd_tool
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+_YEARS = [2020, 2021, 2022, 2023, 2024]
+_ROW = {"corp_code": "00126380", "name": "삼성전자", "ticker": "005930", "dps_krw": 1444.0,
+        "div_total_krw": 9_809_438_000_000.0, "payout_pct": 67.8, "rcept_no": "20250311000001"}
+
+
+# ── screen ───────────────────────────────────────────────────────────────
+def test_screen_render_survives_a_failed_match_count():
+    """매칭 수 COUNT 만 실패 → 예외가 아니라 「세지 못했다」. 실은 수를 매칭 수로 읽히게 두지 않는다."""
+    d = {"status": "ok", "rows": [_ROW], "matched": None, "n_universe": None,
+         "returned": 1, "limit": 50}
+    md = dd_tool._render_screen(2024, [], d, 50, _YEARS, {})
+    assert "세지 못했다" in md and "모집단 조회 실패" in md
+    assert "None사" not in md
+    assert "조건에 걸린 회사 1사" not in md, "실은 수를 매칭 수로 찍었다"
+    assert "조건에 맞는 회사가 없다" not in md
+
+
+def test_screen_render_marks_a_failed_history_lookup_instead_of_pre_listing():
+    """이력열 질의 실패(`hist=None`)는 `-`(상장 전)가 아니라 `?`(모른다)다."""
+    d = {"status": "ok", "rows": [_ROW], "matched": 1, "n_universe": 700, "returned": 1, "limit": 50}
+    md = dd_tool._render_screen(2024, [], d, 50, _YEARS, None)
+    assert "| ? |" in md and "이력열을 읽지 못했다" in md
+    ok = dd_tool._render_screen(2024, [], d, 50, _YEARS, {"00126380": [4, 4, 4, 4, 4]})
+    assert "| 4·4·4·4·4 |" in ok and "읽지 못했다" not in ok
+
+
+def test_screen_legend_says_dash_means_unknown_not_only_pre_listing():
+    d = {"status": "ok", "rows": [_ROW], "matched": 1, "n_universe": 700, "returned": 1, "limit": 50}
+    md = dd_tool._render_screen(2024, [], d, 50, _YEARS, {"00126380": [None, None, 2, 4, 4]})
+    assert "상장 여부를 모른다" in md and "krx_listing" in md
+
+
+def test_payment_history_returns_none_on_query_failure(monkeypatch):
+    """질의 실패를 「전 회사 상장 전」 배열로 메우지 않는다."""
+    monkeypatch.setattr(dd, "_rows", lambda sql, params=(): None)
+    assert dd.payment_history([("00126380", "005930")], 2020, 2024) is None
+
+
+def test_payment_history_distinguishes_zero_unknown_and_count(monkeypatch):
+    rows = [
+        ("A", 2020, None, 12, "20191230", False),   # 상장 중 · 결의 없음 → 0
+        ("A", 2021, 2, 12, "20191230", False),      # 결의 2건
+        ("B", 2020, None, 12, "20210315", False),   # FY2020 말일엔 상장 전 → null
+        ("B", 2021, 1, 12, "20210315", False),
+        ("C", 2020, None, 12, None, None),          # krx_listing 에 없음 → null
+        ("C", 2021, None, 12, None, None),
+    ]
+    monkeypatch.setattr(dd, "_rows", lambda sql, params=(): rows)
+    out = dd.payment_history([("A", "1"), ("B", "2"), ("C", None)], 2020, 2021)
+    assert out == {"A": [0, 2], "B": [None, 1], "C": [None, None]}
+
+
+# ── firm ─────────────────────────────────────────────────────────────────
+def _firm_with(monkeypatch, annual, quarterly):
+    def _rows(sql, params=()):
+        return annual if "FROM div_declared" in sql else quarterly
+    monkeypatch.setattr(dd, "_rows", _rows)
+    return dd.firm_history("00126380", 2020, 2025)
+
+
+def test_firm_history_flags_a_failed_annual_query_without_dropping_quarterly(monkeypatch):
+    qtr = [(2024, "11012", "Q2", 2_450_000_000_000, 2_450_000_000_000, None, "확정", "20240814000001")]
+    d = _firm_with(monkeypatch, None, qtr)
+    assert d["status"] == "ok"
+    assert d["annual_failed"] is True and d["quarterly_failed"] is False
+    assert len(d["quarterly"]) == 1 and d["annual"] == []
+
+
+def test_firm_history_both_failed_is_db_error(monkeypatch):
+    assert _firm_with(monkeypatch, None, None) == {"status": "db_error"}
+
+
+def test_firm_render_says_unknown_not_absent_when_only_the_annual_query_failed():
+    pay = {"status": "ok", "complete_years": _YEARS, "rows": [], "decisions": []}
+    d = {"status": "ok", "annual_failed": True, "quarterly_failed": False,
+         "empty_kind_rows_folded": 0, "annual": [], "quarterly": []}
+    md = dd_tool._render_firm("삼성전자", "005930", d, pay)
+    assert "연간 원장을 읽지 못했다" in md
+    assert "원장이 이 구간에 없다" not in md
+    d2 = {**d, "annual_failed": False, "quarterly_failed": True}
+    md2 = dd_tool._render_firm("삼성전자", "005930", d2, pay)
+    assert "분기 원장을 읽지 못했다" in md2 and "원장 분기 확정 없음" not in md2
+
+
+def test_firm_render_still_says_absent_when_the_query_succeeded_with_nothing():
+    pay = {"status": "ok", "complete_years": _YEARS, "rows": [], "decisions": []}
+    d = {"status": "ok", "annual_failed": False, "quarterly_failed": False,
+         "empty_kind_rows_folded": 0, "annual": [], "quarterly": []}
+    md = dd_tool._render_firm("테스트", "000000", d, pay)
+    assert "원장이 이 구간에 없다" in md and "읽지 못했다" not in md
+
+
+# ── dividend_disclosure 결정공시 합산 경로의 자(尺) ────────────────────────
+def test_decisions_summary_cash_dps_already_contains_the_special_portion():
+    """결정공시의 「1주당 배당금」은 정기·특별분이 합산된 한 숫자다 — `total_dps = cash_dps`,
+    `special_dps` 는 그중 특별분(정보용). 원장 경로(`cash + special`)와 자가 다르다는 것을
+    주석뿐 아니라 코드로 잠근다(삼성전자 FY2020: 1,932 중 1,578)."""
+    from open_proxy_mcp.services.dividend import _decisions_summary_for_year
+    s = _decisions_summary_for_year([{
+        "rcept_dt": "2021-01-28", "rcept_no": "20210128800069", "record_date": "2020-12-31",
+        "dividend_type": "결산배당", "dps_common": 1932, "dps_preferred": 1933,
+        "total_amount": 13_124_000_000_000, "has_special": True, "special_dps_krw": 1578,
+    }], 2020, 12)
+    assert s["cash_dps"] == 1932 and s["total_dps"] == 1932
+    assert s["special_dps"] == 1578 and s["special_dps"] <= s["cash_dps"]
+    assert s["source"] == "decisions"
+
+
+# ── 카탈로그 검사가 없는 도구명을 잡는다 ──────────────────────────────────
+def test_tool_catalog_check_rejects_retired_tool_names_in_descriptions():
+    """`ref:`·`when:` 이 `dividend`(260902 은퇴)를 가리키던 16곳의 회귀 가드 — 검사가
+    통과해야 하고, 은퇴한 이름을 다시 넣으면 그 검사가 잡아야 한다."""
+    sys.path.insert(0, str(ROOT / "scripts"))
+    import check_tool_catalog as c
+
+    class _T:
+        def __init__(self, name, description):
+            self.name, self.description = name, description
+
+    runtime = {"dividend_disclosure", "dividend_data", "evidence"}
+    ok = _T("x", "desc: ..\n        when: 배당 상세는 `dividend_disclosure`.\n        ref: dividend_disclosure, evidence")
+    assert c._description_problems([ok], runtime) == []
+    bad = _T("y", "when: 배당 상세는 `dividend`.\n        ref: dividend, evidence (유형별 심층)")
+    probs = c._description_problems([bad], runtime)
+    assert any("은퇴한 도구명" in p and "dividend" in p for p in probs)
+    assert any("런타임에 없는 도구 dividend" in p for p in probs)
+    # 코드 목록은 도구명이 아니다 — screener 의 유형 코드 `dividend` 를 오탐하지 않는다.
+    codes = _T("screener", "types: order,treasury,dividend,dilutive\n        ref: evidence")
+    assert c._description_problems([codes], runtime) == []
+    # 산문도 도구명이 아니다(`evidence`: 「모든 data/action tool」). 밑줄 든 오타는 잡는다.
+    prose = _T("evidence", "ref: 모든 data/action tool")
+    assert c._description_problems([prose], runtime) == []
+    typo = _T("z", "ref: dividend_disclosur, evidence")
+    assert any("dividend_disclosur" in p for p in c._description_problems([typo], runtime))
+
+    r = subprocess.run([sys.executable, str(ROOT / "scripts" / "check_tool_catalog.py")],
+                       capture_output=True, text=True)
+    assert r.returncode == 0, r.stdout + r.stderr

--- a/wiki/tools/README.md
+++ b/wiki/tools/README.md
@@ -1,7 +1,7 @@
 ---
 type: readme
 title: tools/ — 도구 카탈로그
-updated: 2026-09-02
+updated: 2026-09-03
 ---
 
 # 도구(Tool) 카탈로그
@@ -146,7 +146,7 @@ tool별로 `scope.summary`, `fetch_decisions`, `decision_details`, `load_report_
 | shareholder_meeting_notice | ✅ list/document | - | - | - |
 | shareholder_meeting_results | ✅ list/document | 🔧 fallback | - | - |
 | ownership_structure | ✅ 사업보고서/majorstock | ✅ changes scope | - | - |
-| dividend | ✅ alotMatter | - | - | - |
+| dividend_disclosure | ✅ alotMatter | - | - | - |
 | financial_metrics | ✅ fnlttSinglAcnt + Indx + AcntAll + audit | - | - | - |
 | treasury_share | ✅ DS005 5종 | - | - | - |
 | value_up | ✅ list/document | ✅ 0184 fallback | - | - |
@@ -171,7 +171,7 @@ tool별로 `scope.summary`, `fetch_decisions`, `decision_details`, `load_report_
 | evidence | - | - | - | - (문자열 가공) |
 | law_lookup | - | - | - | ✅ legalize-kr 법령 corpus 10법(4법 + 260902 확장 지배구조법·상증세법·금융지주회사법·금산법·은행법·보험업법) + 40룰 bridge |
 | proxy_advise_before_meeting | upstream data tools | upstream | - | 판단 규칙/records |
-| shareholder_commitment | ✅ value_up+corp_gov_report+dividend+treasury_share+financial_metrics+stockTotqySttus (전부 재사용) | - | - | - |
+| shareholder_commitment | ✅ value_up+corp_gov_report+dividend_disclosure+treasury_share+financial_metrics+stockTotqySttus (전부 재사용) | - | - | - |
 
 ✅ = 1차 source / 🔧 = 보조
 
@@ -192,6 +192,7 @@ tool별로 `scope.summary`, `fetch_decisions`, `decision_details`, `load_report_
 - 2026-05-31: financial_metrics 56 지표 확장 · value_up 역할 분리
 - 2026-06-20: 카탈로그를 사람용("무엇을 답하나")으로 재정리 + 개발 상세 분리
 - 2026-07-13: **law_lookup 신규(21번째 tool)** — 정관↔법령 양방향 조회. legalize-kr 원문 corpus(당시 4법: 상법·자본시장법·공정거래법·외부감사법) + 40룰 bridge, 회사·DART 무관. Evidence 카테고리 1→2
+- 2026-09-03: **옛 도구명 `dividend` 잔재 정리 + 카탈로그 검사 확장** — 260902 개명 뒤 도구 설명 `ref:`·`when:` 16곳과 wiki 5곳이 없는 이름 `dividend` 를 가리키고 있었다(읽는 쪽이 LLM 이라 그대로 호출한다). 전부 `dividend_disclosure` 로. `check_tool_catalog.py` 가 이제 `ref:` 토큰을 런타임과 대조하고, 은퇴한 이름(`usage_tracker.TOOL_ALIASES` 키)이 설명에 서 있으면 실패한다. 같은 날 `dividend_data` 의 부분 장애 경로(매칭 수·원장·이력열 질의 하나만 실패)를 「없다」·예외 대신 「모른다」로 렌더하도록 고침.
 - 2026-09-02: **law_lookup 코퍼스 4법 → 10법** — 금융회사 지배구조법·상증세법·금융지주회사법·금산법·은행법·보험업법 추가(조문 2,734 → 3,949). 법 우선순위·제목 앵커로 옛 4법 질의 정확도 유지(harness recall@10 85%).
 - 2026-07-15: **screener 신규(22번째 tool)** — 전체시장 공시 스크리너 / 아침 디제스트. scan(전체시장 list.json market-scan, 하루 4콜)+details(유형별 파서 재사용). 시총=krx_weekly(DART 0콜)
 - 2026-07-15: **screener `domain: action` 재분류** — Screening 카테고리를 Action으로 흡수(2→3). upstream 파서 오케스트레이션 + 디제스트/루틴 구동(액션 산출물). 루틴 레시피 [docs/routines](../../docs/routines/screener-morning-digest.md) 연동

--- a/wiki/tools/dividend_data.md
+++ b/wiki/tools/dividend_data.md
@@ -65,7 +65,8 @@ dividend_data(scope="sector", sector="금융", year_from=2020, year_to=2025)
 |---|---|
 | `4`·`2`·`1` | 그 사업연도 실제 결의 횟수 |
 | `0` | **배당 안 함** — 그 사업연도 말일 시점에 상장 중이었는데 결의가 없었다 |
-| `-`(null) | **모름** — 아직 상장 전이라 애초에 물을 수 없다 |
+| `-`(null) | **모름** — 그 사업연도 말일 시점에 아직 상장 전이거나, 티커가 `krx_listing` 에 없어 상장 여부를 알 수 없다 |
+| `?` | **조회 실패** — 이력 질의 자체가 실패했다. `-` 로 메우지 않고 따로 표시한다 |
 
 상장 여부는 `krx_listing`(`krx_weekly` 주간 시세의 티커별 첫 관측일 파생, 별도 배치로
 구움 — 요청마다 계산하면 3,257종목 전 스캔이 280ms 라 도구 안에서 못 쓴다)으로 가른다.
@@ -128,6 +129,17 @@ dividend_data(scope="sector", sector="금융", year_from=2020, year_to=2025)
 옛 쿼리가 깨졌는데 화면에는 「결정공시 집계가 없다」로 나왔다 — 이 서비스가 내내 막아 온
 바로 그 사고다. 회귀 테스트로 고정했다(`tests/test_dividend_raw_cells.py`).
 
+같은 원칙이 **질의 하나만 실패하는 부분 장애**에도 걸린다(260903 점검,
+`tests/test_dividend_data_failure_paths.py`):
+
+| 실패한 질의 | 전에는 | 지금은 |
+|---|---|---|
+| `firm` 연간 원장만 | 「원장이 이 구간에 없다」 | 「연간 원장을 읽지 못했다 — 모른다」 (`annual_failed`) |
+| `firm` 분기 원장만 | 「분기 확정 없음」 | 「분기 원장을 읽지 못했다」 (`quarterly_failed`) |
+| `screen` 매칭 수 COUNT | `len(rows) < None` 예외로 도구가 죽음 | 「매칭 수를 세지 못했다 — 실은 N사는 전체가 아니다」 |
+| `screen` 모집단 COUNT | 「모집단 None사」 | 「모집단 조회 실패」 |
+| `screen` 이력열 | 전 회사 `-`(상장 전으로 읽힘) | `?` + 「이력열을 읽지 못했다」 (`payment_history_failed`) |
+
 ## 못 하는 것 — 먼저 밝힌다
 - **보통/우선 배당총액 배분값을 내지 않는다.** 종류별 발행주식수가 서식에 없어 검산이 57.2%만
   맞았다. 신고총액 하나만 낸다.
@@ -145,3 +157,9 @@ dividend_data(scope="sector", sector="금융", year_from=2020, year_to=2025)
 
 ## 관련
 [[dividend_disclosure]] · [[price_multiple_data]] · [[forward_estimates_data]] · [[screener]] · [[evidence]]
+
+## 변경 이력
+- 2026-09-03: 부분 장애 경로 정리 — 매칭 수·모집단·원장·이력열 질의 하나만 실패해도 예외나
+  「없다」 대신 「모른다」로 렌더. 이력열 `-` 범례를 「상장 여부를 모름」으로 넓히고 조회
+  실패는 `?` 로 분리. 도구 설명의 옛 이름 `dividend` → `dividend_disclosure`.
+- 2026-09-03: `dividend_history_data`+`dividend_screener` 통합으로 신설. 결정공시 비고 원문 전문 반환.

--- a/wiki/tools/proxy_advise_before_meeting.md
+++ b/wiki/tools/proxy_advise_before_meeting.md
@@ -395,7 +395,7 @@ sequenceDiagram
 
 **+ 사내이사 연임 후보 detect 시 추가 chain (회사 단위 1회)**:
 
-7. dividend (history, 10년) — CSR avg/trend 계산
+7. dividend_disclosure (history, 10년) — CSR avg/trend 계산
 8. treasury_share (summary, **동적 lookback** 36~120개월) — 소각 events. 가장 오래 재직한
    사내이사 기준 `(target-min(earliest_start)+2)*12`로 좁힘(상한 120, detect fail시 120).
    소각은 재직기간만 CSR에 쓰여 정확도 보존

--- a/wiki/tools/screener.md
+++ b/wiki/tools/screener.md
@@ -5,7 +5,7 @@ domain: action
 updated: 2026-08-25
 scope: [core preset, all, 유형 CSV]
 data_source: [DART OpenAPI list.json (corp_code 無 전체시장 필러) + krx_weekly (시총, DART 0콜) + 유형별 파서 재사용(details)]
-related: [order_contracts, treasury_share, dividend, dilutive_issuance, shareholder_meeting_notice, ownership_structure]
+related: [order_contracts, treasury_share, dividend_disclosure, dilutive_issuance, shareholder_meeting_notice, ownership_structure]
 ---
 
 # screener — 전체시장 공시 스크리너 / 아침 디제스트
@@ -14,7 +14,7 @@ related: [order_contracts, treasury_share, dividend, dilutive_issuance, sharehol
 **매일 아침 출근길 공시 알람 디제스트** — "직전 실행 이후~오늘 전종목에 뭐가 떴나"를 폰에서 훑기 좋게
 (기업명 + 시총 + 유형 + 단계 + 정정 프리픽스 + 분모% + DART/naver 링크). 벤치마크는 텔레그램 AWAKE.
 
-개별 tool(order_contracts·dividend 등)이 **한 회사를 깊게** 판다면, screener는 **전체시장을 얕게**
+개별 tool(order_contracts·dividend_disclosure 등)이 **한 회사를 깊게** 판다면, screener는 **전체시장을 얕게**
 훑어 "무엇이 떴나"를 싸게 답한다. 거버넌스는 유형의 부분집합 — 범용 공시 디제스트다.
 
 ### 회계기간 메타데이터

--- a/wiki/tools/shareholder_commitment.md
+++ b/wiki/tools/shareholder_commitment.md
@@ -3,7 +3,7 @@ type: tool
 title: shareholder_commitment
 domain: action
 scope: [단일 조회]
-data_source: [value_up(계획), corp_gov_report(준수변화), dividend(실제배당), treasury_share(실제소각), financial_metrics(자기자본), DART stockTotqySttus(유통주식수)]
+data_source: [value_up(계획), corp_gov_report(준수변화), dividend_disclosure(실제배당), treasury_share(실제소각), financial_metrics(자기자본), DART stockTotqySttus(유통주식수)]
 related_disclosures: [기업가치제고계획, 기업지배구조보고서, 배당결정, 자기주식결정]
 related_concepts: [자사주, 주주환원, BPS, PBR]
 created: 2026-07-07
@@ -42,7 +42,7 @@ sequenceDiagram
     participant T as shareholder_commitment
     participant V as value_up (commitments)
     participant G as corp_gov_report (timeline)
-    participant D as dividend (summary+history)
+    participant D as dividend_disclosure (summary+history)
     participant TS as treasury_share (summary)
     participant F as financial_metrics (summary)
     participant S as DART stockTotqySttus

--- a/wiki/tools/shareholder_meeting_results.md
+++ b/wiki/tools/shareholder_meeting_results.md
@@ -73,5 +73,5 @@ sequenceDiagram
 ## ref
 
 - 사전 안건/후보: [[shareholder_meeting_notice]]
-- 후속 공시(배당/자사주/구조 등)는 dividend·treasury_share 등 각 tool 직접 호출 (proxy_result_after_meeting은 2026-06-13 archive)
+- 후속 공시(배당/자사주/구조 등)는 dividend_disclosure·treasury_share 등 각 tool 직접 호출 (proxy_result_after_meeting은 2026-06-13 archive)
 - 원문: [[evidence]]


### PR DESCRIPTION
## 왜

PR #14·#15 배포분 점검에서 나온 6건. 배포·DB·테스트는 전부 정상이었고, 아래는 코드·문서 간극과 부분 장애 경로다.

## 무엇

**1. 없는 도구 `dividend` 를 호출하라고 안내하던 21곳**
260902 개명(`dividend` → `dividend_disclosure`) 뒤 도구 설명 `ref:`·`when:` 16곳(company·treasury_share·forward_estimates_data·shareholder_meeting_results·financial_metrics·value_up·screener·shareholder_commitment·price_multiple_data·dividend_data)과 prompts·services 안내문, wiki 5곳이 옛 이름 그대로였다. 읽는 쪽이 LLM 이라 그대로 호출한다. 전부 `dividend_disclosure` 로.

`check_tool_catalog.py` 확장 — `ref:` 의 도구명 토큰(밑줄 든 식별자·은퇴한 이름)을 런타임과 대조하고, 은퇴한 이름(`usage_tracker.TOOL_ALIASES` 키)이 백틱 안이나 `ref:`·`when:` 줄에 서 있으면 실패. `screener` 의 유형 코드 `dividend`(`types:` 줄)와 `evidence` 의 「모든 data/action tool」 산문은 오탐하지 않는다.

**2. `dividend_data` — 질의 하나만 실패하는 부분 장애**

| 실패한 질의 | 전에는 | 지금은 |
|---|---|---|
| `screen` 매칭 수 COUNT | `len(rows) < None` TypeError 로 도구가 죽음 | 「매칭 수를 세지 못했다 — 실은 N사는 전체가 아니다」 |
| `screen` 모집단 COUNT | 「모집단 None사」 | 「모집단 조회 실패」 |
| `screen` 이력열 | 전 회사 `-`(상장 전으로 읽힘) | `?` + 「이력열을 읽지 못했다」, json `payment_history_failed` |
| `firm` 연간 원장만 | 「원장이 이 구간에 없다」 | 「연간 원장을 읽지 못했다 — 모른다」 (`annual_failed`) |
| `firm` 분기 원장만 | 「분기 확정 없음」 | 「분기 원장을 읽지 못했다」 (`quarterly_failed`) |

이력열 `-` 범례를 「상장 여부를 모름(상장 전이거나 `krx_listing` 에 없음)」으로 넓혔다 — 실제로 그 두 경우에 같은 `-` 가 나온다.

**3. `services/dividend.py` `special_dps` 주석 정정**
결정공시 합산 경로는 「1주당 배당금」이 정기·특별 합산이라 `cash_dps` 에 특별분이 이미 들어 있고 `total_dps = cash` 다(삼성전자 FY2020: 1,932 중 1,578). 주석이 원장 경로의 자(`cash + special`)를 적고 있었다. 값은 그대로, 주석과 테스트로 자를 명시.

## 검증
- `1,466 passed` (신규 `tests/test_dividend_data_failure_paths.py` 11건).
- `check_tool_catalog.py` 31개 통과 — 은퇴한 이름을 되돌려 넣으면 실패하는 것을 단위 테스트로 확인.
- `wiki_lint --strict` · `gen_index --check` · `check_documentation_contract` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tX9Aa9zuF3cM5BwAhSwU6

---
_Generated by [Claude Code](https://claude.ai/code/session_017tX9Aa9zuF3cM5BwAhSwU6)_