### PR TITLE
feat(forward_estimates): bundle=revision — 4주·12주 전 대비 추정 변화 (fwd_hist)

### DIFF
--- a/open_proxy_mcp/services/forward_estimates.py
+++ b/open_proxy_mcp/services/forward_estimates.py
@@ -156,7 +156,127 @@ _ABSENT_ON_ESTIMATE = {
                          "주당값 검산은 봉투의 shares_common_latest(최근 실적 행 주식수)로 한다",
 }
 
-_BUNDLES = ("core", "growth", "quality", "keys")
+_BUNDLES = ("core", "growth", "quality", "keys", "revision")
+
+# ─────────────────────────────────────────────────────────────────────────────
+# revision — 컨센서스가 **어디서 왔나** (260904 신설)
+#
+# `fwd` 는 「지금 얼마」만 답한다. 추정치의 방향 전환은 주가보다 먼저 움직이는 신호라
+# 「4주·12주 전 대비 얼마나 올랐/내렸나」를 `fwd_hist`(슬림 18칸 · 추정 보유 종목 · 주 1회 토 ·
+# 13주 롤링, 260904 신설)에서 읽는다. 기준일은 **목표일 이전의 가장 가까운 스냅샷**이다 —
+# 주 1회라 정확히 28일 전은 없다. 이력이 목표일까지 안 닿으면 가장 오래된 스냅샷을 쓰고
+# `partial=true` 로 밝힌다(「없음」과 「짧음」을 구별한다). 분모는 |기준값| — 적자에서 흑자로
+# 돌아선 것도 방향은 「상향」이다.
+# ─────────────────────────────────────────────────────────────────────────────
+_REV_WINDOWS: tuple[tuple[str, int], ...] = (("4w", 28), ("12w", 91))
+_REV_METRICS: tuple[str, ...] = ("rev_krw", "op_krw", "ni_ctrl_krw", "eps_krw", "dps_krw")
+_REV_MIN_GAP_DAYS = 6  # 이보다 가까운 스냅샷은 「전」이 아니다
+
+
+def _pct(now: Any, base: Any) -> float | None:
+    if now is None or base is None:
+        return None
+    try:
+        b = abs(float(base))
+        if b == 0:
+            return None
+        return round((float(now) - float(base)) / b * 100, 2)
+    except (TypeError, ValueError):
+        return None
+
+
+def compute_revision(hist: list[dict[str, Any]], windows=_REV_WINDOWS) -> dict[str, Any]:
+    """`fwd_hist` 추정 행들(dict: as_of·period·period_type·<metrics>) → 리비전 표.
+
+    반환:
+      as_of_latest, snapshots(이력 날짜 수), baselines{win: {as_of, days, partial}},
+      rows[{period, period_type, now{...}, vs{win: {as_of, <metric>_pct...}}}],
+      summary{win: {up, down, flat, n, basis:"op_krw"}}
+    hist 가 비면 rows=[] 로 돌려준다 — 호출부가 「자료 없음」으로 말한다.
+    """
+    if not hist:
+        return {"as_of_latest": None, "snapshots": 0, "baselines": {}, "rows": [], "summary": {}}
+    import datetime as _dt
+
+    def _d(v: Any) -> _dt.date:
+        return v if isinstance(v, _dt.date) else _dt.date.fromisoformat(str(v)[:10])
+
+    by_day: dict[_dt.date, dict[tuple[str, str], dict[str, Any]]] = {}
+    for r in hist:
+        by_day.setdefault(_d(r["as_of"]), {})[(r["period"], r["period_type"])] = r
+    days = sorted(by_day)
+    latest = days[-1]
+    baselines: dict[str, dict[str, Any]] = {}
+    for name, span in windows:
+        target = latest - _dt.timedelta(days=span)
+        cands = [d for d in days if d <= target]
+        if cands:
+            b, partial = cands[-1], False
+        else:
+            older = [d for d in days if (latest - d).days >= _REV_MIN_GAP_DAYS]
+            if not older:
+                continue
+            b, partial = older[0], True
+        baselines[name] = {"as_of": b.isoformat(), "days": (latest - b).days, "partial": partial}
+
+    rows: list[dict[str, Any]] = []
+    summary: dict[str, dict[str, Any]] = {n: {"up": 0, "down": 0, "flat": 0, "n": 0, "basis": "op_krw"}
+                                          for n in baselines}
+    for key, cur in sorted(by_day[latest].items(), key=lambda kv: (kv[0][1], kv[0][0])):
+        period, ptype = key
+        now = {m: cur.get(m) for m in _REV_METRICS if cur.get(m) is not None}
+        vs: dict[str, Any] = {}
+        for name, b in baselines.items():
+            base = by_day[_d(b["as_of"])].get(key)
+            if base is None:
+                vs[name] = {"as_of": b["as_of"], "absent": True}   # 그때는 이 기간 추정이 없었다
+                continue
+            cell: dict[str, Any] = {"as_of": b["as_of"]}
+            for m in _REV_METRICS:
+                p = _pct(cur.get(m), base.get(m))
+                if p is not None:
+                    cell[f"{m}_pct"] = p
+            vs[name] = cell
+            op = cell.get("op_krw_pct")
+            if op is not None and ptype == "FY":
+                s = summary[name]
+                s["n"] += 1
+                s["up" if op > 0.5 else "down" if op < -0.5 else "flat"] += 1
+        rows.append({"period": period, "period_type": ptype, "now": now, "vs": vs})
+    return {"as_of_latest": latest.isoformat(), "snapshots": len(days),
+            "baselines": baselines, "rows": rows, "summary": summary}
+
+
+_hist_cache: dict[str, Any] = {"at": 0.0, "ok": None}
+
+
+def _hist_available() -> bool | None:
+    """`fwd_hist` 표가 있나 — 10분 캐시. None = DB 장애.
+    없는 표를 바로 질의하면 db.pg_rows 가 풀을 60초 내린다(질의 오류를 장애로 본다) —
+    그래서 `to_regclass` 로 먼저 묻는다. 이건 표가 없어도 오류가 아니다."""
+    now = time.monotonic()
+    if _hist_cache["ok"] is not None and now - _hist_cache["at"] < 600:
+        return _hist_cache["ok"]
+    r = pg_rows("SELECT to_regclass('public.fwd_hist') IS NOT NULL")
+    if r is None:
+        return None
+    _hist_cache.update(at=now, ok=bool(r and r[0][0]))
+    return _hist_cache["ok"]
+
+
+def _fetch_hist(stock_code: str) -> list[dict[str, Any]] | None:
+    """`fwd_hist` 추정 행 전부(13주 롤링이라 많아야 ~150행). None = DB 장애. [] = 표 없음/이력 없음."""
+    avail = _hist_available()
+    if avail is None:
+        return None
+    if not avail:
+        return []
+    cols = ("as_of", "period", "period_type") + _REV_METRICS
+    rows = pg_rows(f"SELECT {', '.join(cols)} FROM fwd_hist "
+                   "WHERE stock_code=%s AND is_estimate ORDER BY as_of", (stock_code,))
+    if rows is None:
+        return None
+    return [dict(zip(cols, r)) for r in rows]
 
 #: 배수 분모 자 — PER 정의를 `price_multiple_data` 와 **맞춘다**(보통주 시총 ÷ 지배순이익).
 #: 왜: `fwd` 원본은 주가÷EPS 인데 그 식은 260823 에 하우스에서 **의도적으로 버린 것**이다
@@ -492,6 +612,27 @@ async def build_forward_estimates_payload(
     absent = {k: v for k, v in _ABSENT_ON_ESTIMATE.items()
               if _spec(k)[2] in bundles} if est_rows else {}
 
+    # ── revision: 4주·12주 전 대비 (fwd_hist) ──────────────────────────────────
+    revision: dict[str, Any] | None = None
+    if "revision" in bundles and est_rows:
+        hist = await asyncio.to_thread(_fetch_hist, isu)
+        if hist is None:
+            warnings.append("⚠ 리비전 이력(`fwd_hist`) 조회 실패 — **장애**다, 자료 없음이 아니다. "
+                            "현재 추정치는 정상이다. 재시도할 것.")
+        else:
+            revision = compute_revision(hist)
+            if not revision["rows"]:
+                warnings.append("리비전 이력이 없다 — `fwd_hist` 에 이 종목 추정 행이 없다"
+                                "(260904 신설 표, 주 1회 토요일 적재). 현재 추정치는 정상이다.")
+            elif not revision["baselines"]:
+                warnings.append(f"리비전 비교 불가 — 이력이 {revision['snapshots']}개 스냅샷뿐이라 "
+                                f"{_REV_MIN_GAP_DAYS}일 이상 떨어진 기준일이 없다. 다음 주부터 4w 가 잡힌다.")
+            else:
+                for name, b in revision["baselines"].items():
+                    if b["partial"]:
+                        warnings.append(f"리비전 {name}: 이력이 {b['days']}일치뿐이라 가장 오래된 "
+                                        f"스냅샷({b['as_of']})과 비교했다 — **{name} 가 아니다**, 이력이 짧아 부분 비교다.")
+
     ruler = {
         "as_of": str(env.get("as_of")) if env.get("as_of") else None,
         "price_dd": env.get("price_dd"),
@@ -526,10 +667,15 @@ async def build_forward_estimates_payload(
         data["fields_absent_note"] = ("아래 칸은 **이 회사에 자료가 없어서가 아니라** 벤더가 "
                                       "추정 행에 아예 채우지 않는 종류라서 비어 있다. "
                                       "회사 특성으로 읽지 말 것.")
-    if "growth" not in bundles or "quality" not in bundles or "keys" not in bundles:
+    if revision is not None:
+        revision["note"] = ("기준일은 목표일(4w=28일·12w=91일) **이전의 가장 가까운 주간 스냅샷**. "
+                            "%는 (지금−기준)/|기준|. 방향 집계는 FY 추정 행의 영업이익 기준 상향/하향 개수"
+                            "(±0.5% 안은 flat). 출처 `fwd_hist`(주 1회 토, 13주 롤링) — 그 너머는 없다.")
+        data["revision"] = revision
+    if len(bundles) < len(_BUNDLES):
         data["more"] = ("더 필요하면 bundle 을 넓히세요 — "
                         "growth(성장률·전기값·PEG) · quality(수익성·재무비율) · "
-                        "keys(내부키·회계연도 칸) · all(전부). "
+                        "keys(내부키·회계연도 칸) · revision(4주·12주 전 대비 추정 변화) · all(전부). "
                         "기본 core 는 크기를 줄이려고 자른 것이지 그것이 정답이라서가 아니다.")
     return {"tool": TOOL, "status": "ok" if est_rows else "no_estimates",
             "subject": subject, "data": data, "warnings": warnings}

--- a/open_proxy_mcp/tools/forward_estimates_data.py
+++ b/open_proxy_mcp/tools/forward_estimates_data.py
@@ -100,6 +100,36 @@ def _render(p: dict[str, Any]) -> str:
                      f"{g.get('ni_ctrl_growth_disp') or _num(g.get('ni_ctrl_growth_pct'), '%')} | "
                      f"{g.get('eps_growth_disp') or _num(g.get('eps_growth_pct'), '%')} |")
 
+    rev = d.get("revision")
+    if rev and rev.get("rows"):
+        wins = list(rev.get("baselines") or {})
+        L += ["", "### 리비전 — 추정치가 어디서 왔나", "", f"_{rev.get('note')}_", ""]
+        if wins:
+            L.append("기준일: " + " · ".join(
+                f"**{w}** = {rev['baselines'][w]['as_of']} ({rev['baselines'][w]['days']}일 전"
+                + (", 이력 짧음" if rev['baselines'][w].get('partial') else "") + ")" for w in wins))
+            L += ["", "| 기간 | 지금 영업이익 | " + " | ".join(f"매출 {w}" for w in wins)
+                  + " | " + " | ".join(f"영업이익 {w}" for w in wins)
+                  + " | " + " | ".join(f"EPS {w}" for w in wins) + " |",
+                  "|---|---|" + "---|" * (3 * len(wins))]
+            for row in rev["rows"]:
+                if row.get("period_type") != "FY":
+                    continue
+                vs = row.get("vs") or {}
+                cell = lambda w, m: ("없었음" if (vs.get(w) or {}).get("absent")
+                                     else _num((vs.get(w) or {}).get(f"{m}_pct"), "%", "{:+.1f}"))
+                L.append(f"| {row['period']} | {_won((row.get('now') or {}).get('op_krw'))} | "
+                         + " | ".join(cell(w, "rev_krw") for w in wins) + " | "
+                         + " | ".join(cell(w, "op_krw") for w in wins) + " | "
+                         + " | ".join(cell(w, "eps_krw") for w in wins) + " |")
+            s = rev.get("summary") or {}
+            L.append("")
+            L.append("방향(FY 영업이익): " + " · ".join(
+                f"{w} 상향 {s[w]['up']} / 하향 {s[w]['down']} / 유지 {s[w]['flat']} (n={s[w]['n']})"
+                for w in wins if w in s))
+        else:
+            L.append(f"이력 {rev.get('snapshots')}개 스냅샷 — 비교할 기준일이 아직 없다.")
+
     absent = d.get("fields_absent_by_design")
     if absent:
         L += ["", "### 추정 행에 원래 없는 칸", "", f"_{d.get('fields_absent_note')}_", ""]
@@ -119,8 +149,8 @@ def register_tools(mcp):
                                      period_type: str = "FY", actual_years: int = 2,
                                      format: str = "md") -> str:
         """desc: 컨센서스 **포워드 추정치**(내년·내후년 예상 매출·영업이익·EPS·PER/PBR/PSR·성장률) + 대조용 최근 실적. 애널리스트 추정 스냅샷(`fwd`) 기반 — DART 공시가 아니다.
-        when: "삼성전자 내년 예상 PER"·"2027년 컨센서스 영업이익"·"내년 실적 전망"·"포워드 밸류에이션"·"추정 EPS 성장률". 확정 실적 기반 현재 배수는 `price_multiple_data`(scope=firm), 재무 원본은 `financial_metrics`, 배당 상세는 `dividend_disclosure`.
-        rule: **자(尺)를 두 겹으로 싣는다** — 봉투 `ruler`(as_of·**price_dd**·단위·PER 정의·배수 범위)에 한 번, 행마다 또(`period`·`row_kind`·`basis`). 🔴 `as_of` 와 `price_dd` 는 다르다(주말·휴일) — 배수는 **price_dd 종가** 기준이므로 "as_of 기준 PER"이라고 쓰면 틀린다. 행은 실적/추정이 아니라 **`reported`(벤더 원천, 틀리면 벤더 책임) / `derived`(우리 계산, 검산 대상)** 로 가른다 — 성장률이 실적/추정 경계를 넘나들기 때문. **PER=보통주 시총÷지배주주순이익**으로 `price_multiple_data` 와 정의를 맞췄다(벤더 원본은 주가÷EPS인데 그 식은 260823 에 하우스에서 버렸다 — 액면분할 때 옛 주식수 EPS 와 새 주가가 섞인다). 10% 이상 갈리면 경고로 밝힌다. **배수는 추정 FY·최신 확정 FY 행에만** 둔다(오늘 주가÷과거 실적은 배수가 아니다). **금액은 전부 원(KRW) 정수** — 억원 안 쓴다. 빈칸은 채우지 않고 뺀다(0 아님·자료 없음). bundle=core(기본, 좁게) / growth(성장률·전기값·PEG) / quality(수익성·재무비율) / keys(내부키·회계연도) / all — 기본이 정답이 아니라 크기 때문에 자른 것이니 필요하면 넓혀 부를 것. period_type=FY(기본)/Q/all · actual_years=대조용 실적 행 수(기본 2 — 직전 확정 실적 2개년. 추세를 보려면 넓혀 부를 것).
+        when: "삼성전자 내년 예상 PER"·"2027년 컨센서스 영업이익"·"내년 실적 전망"·"포워드 밸류에이션"·"추정 EPS 성장률"·**"컨센서스 상향/하향됐나"·"한 달 전보다 추정치가 올랐나"(bundle=revision)**. 확정 실적 기반 현재 배수는 `price_multiple_data`(scope=firm), 재무 원본은 `financial_metrics`, 배당 상세는 `dividend_disclosure`.
+        rule: **자(尺)를 두 겹으로 싣는다** — 봉투 `ruler`(as_of·**price_dd**·단위·PER 정의·배수 범위)에 한 번, 행마다 또(`period`·`row_kind`·`basis`). 🔴 `as_of` 와 `price_dd` 는 다르다(주말·휴일) — 배수는 **price_dd 종가** 기준이므로 "as_of 기준 PER"이라고 쓰면 틀린다. 행은 실적/추정이 아니라 **`reported`(벤더 원천, 틀리면 벤더 책임) / `derived`(우리 계산, 검산 대상)** 로 가른다 — 성장률이 실적/추정 경계를 넘나들기 때문. **PER=보통주 시총÷지배주주순이익**으로 `price_multiple_data` 와 정의를 맞췄다(벤더 원본은 주가÷EPS인데 그 식은 260823 에 하우스에서 버렸다 — 액면분할 때 옛 주식수 EPS 와 새 주가가 섞인다). 10% 이상 갈리면 경고로 밝힌다. **배수는 추정 FY·최신 확정 FY 행에만** 둔다(오늘 주가÷과거 실적은 배수가 아니다). **금액은 전부 원(KRW) 정수** — 억원 안 쓴다. 빈칸은 채우지 않고 뺀다(0 아님·자료 없음). bundle=core(기본, 좁게) / growth(성장률·전기값·PEG) / quality(수익성·재무비율) / keys(내부키·회계연도) / **revision(4주·12주 전 대비 추정 변화율 + FY 영업이익 상향/하향 개수 — "컨센서스가 오르고 있나"·"최근 리비전 방향"은 이것)** / all — 기본이 정답이 아니라 크기 때문에 자른 것이니 필요하면 넓혀 부를 것. revision 출처는 `fwd_hist`(주 1회 토요일 스냅샷, 13주 롤링, 260904 신설) — 기준일은 목표일 이전 가장 가까운 스냅샷이고 이력이 짧으면 partial 로 밝힌다. period_type=FY(기본)/Q/all · actual_years=대조용 실적 행 수(기본 2 — 직전 확정 실적 2개년. 추세를 보려면 넓혀 부를 것).
         status: ok / **no_estimates**(그 종목은 애널리스트 미커버 — 전체 2,764종목 중 추정 보유 713종목뿐, 74%가 여기 해당. 자료 없음이지 오류 아님) / not_found(그런 종목 없음·오탈자·비상장) / unlisted / ambiguous(동명 후보표) / **db_error**(DB 장애 — 자료 없음과 다르다, 재시도) / invalid. 🔴 셋을 뭉뚱그리지 말 것: no_estimates는 다른 도구로, not_found는 이름 재확인, db_error는 재시도.
 
         ref: price_multiple_data, financial_metrics, dividend_disclosure, company

--- a/tests/test_forward_revision.py
+++ b/tests/test_forward_revision.py
@@ -1,0 +1,96 @@
+"""forward_estimates.compute_revision — 리비전(4주·12주 전 대비) 계산 회귀 (DB/네트워크 0콜).
+
+지키는 것: ① 기준일 = 목표일 이전 가장 가까운 스냅샷 ② 이력이 짧으면 가장 오래된 것 + partial
+③ %는 (지금−기준)/|기준| — 적자→흑자는 상향 ④ 그때 없던 기간은 absent ⑤ summary 는 FY·영업이익만
+⑥ 기준 0/None 은 칸을 뺀다 ⑦ 6일 안쪽만 있으면 baselines 가 빈다.
+"""
+import datetime as dt
+
+from open_proxy_mcp.services import forward_estimates as fe
+
+
+def _row(as_of, period, ptype="FY", **m):
+    d = {"as_of": as_of, "period": period, "period_type": ptype,
+         "rev_krw": None, "op_krw": None, "ni_ctrl_krw": None, "eps_krw": None, "dps_krw": None}
+    d.update(m)
+    return d
+
+
+def _weekly(n_weeks: int, start=dt.date(2026, 6, 6)):
+    return [start + dt.timedelta(weeks=i) for i in range(n_weeks)]
+
+
+def test_empty_history():
+    r = fe.compute_revision([])
+    assert r["rows"] == [] and r["baselines"] == {} and r["snapshots"] == 0
+
+
+def test_baseline_is_nearest_snapshot_at_or_before_target():
+    days = _weekly(14)                       # 13주 + 1 → 12w 기준이 잡힌다
+    hist = [_row(d, "2026.12E", op_krw=100 + i) for i, d in enumerate(days)]
+    r = fe.compute_revision(hist)
+    latest = days[-1]
+    assert r["as_of_latest"] == latest.isoformat()
+    b4 = dt.date.fromisoformat(r["baselines"]["4w"]["as_of"])
+    b12 = dt.date.fromisoformat(r["baselines"]["12w"]["as_of"])
+    assert (latest - b4).days >= 28 and (latest - b4).days < 35      # 28일 이전 중 가장 가까운 것
+    assert (latest - b12).days >= 91 and (latest - b12).days < 98
+    assert r["baselines"]["4w"]["partial"] is False
+    assert r["baselines"]["12w"]["partial"] is False
+
+
+def test_short_history_uses_oldest_and_flags_partial():
+    days = _weekly(2)                        # 7일치뿐
+    hist = [_row(days[0], "2026.12E", op_krw=100), _row(days[1], "2026.12E", op_krw=110)]
+    r = fe.compute_revision(hist)
+    assert r["baselines"]["4w"] == {"as_of": days[0].isoformat(), "days": 7, "partial": True}
+    assert r["baselines"]["12w"]["partial"] is True
+    assert r["rows"][0]["vs"]["4w"]["op_krw_pct"] == 10.0
+
+
+def test_too_close_history_has_no_baseline():
+    d0 = dt.date(2026, 9, 1)
+    hist = [_row(d0, "2026.12E", op_krw=100), _row(d0 + dt.timedelta(days=2), "2026.12E", op_krw=105)]
+    r = fe.compute_revision(hist)
+    assert r["baselines"] == {} and r["rows"] and r["rows"][0]["vs"] == {}
+
+
+def test_pct_uses_abs_base_so_loss_to_profit_is_up():
+    days = _weekly(6)
+    hist = [_row(days[0], "2026.12E", op_krw=-100), _row(days[-1], "2026.12E", op_krw=50)]
+    r = fe.compute_revision(hist)
+    assert r["rows"][0]["vs"]["4w"]["op_krw_pct"] == 150.0
+    assert r["summary"]["4w"] == {"up": 1, "down": 0, "flat": 0, "n": 1, "basis": "op_krw"}
+
+
+def test_zero_or_missing_base_drops_the_cell():
+    days = _weekly(6)
+    hist = [_row(days[0], "2026.12E", op_krw=0, eps_krw=None, rev_krw=200),
+            _row(days[-1], "2026.12E", op_krw=10, eps_krw=5, rev_krw=220)]
+    cell = fe.compute_revision(hist)["rows"][0]["vs"]["4w"]
+    assert "op_krw_pct" not in cell and "eps_krw_pct" not in cell
+    assert cell["rev_krw_pct"] == 10.0
+
+
+def test_period_absent_at_baseline_is_marked_not_zero():
+    days = _weekly(6)
+    hist = [_row(days[0], "2026.12E", op_krw=100),
+            _row(days[-1], "2026.12E", op_krw=100), _row(days[-1], "2028.12E", op_krw=300)]
+    rows = {r["period"]: r for r in fe.compute_revision(hist)["rows"]}
+    assert rows["2028.12E"]["vs"]["4w"] == {"as_of": days[0].isoformat(), "absent": True}
+    assert rows["2026.12E"]["vs"]["4w"]["op_krw_pct"] == 0.0
+
+
+def test_summary_counts_only_fy_and_uses_flat_band():
+    days = _weekly(6)
+    hist = [_row(days[0], "2026.12E", op_krw=100), _row(days[-1], "2026.12E", op_krw=100.4),   # flat
+            _row(days[0], "2027.12E", op_krw=100), _row(days[-1], "2027.12E", op_krw=90),      # down
+            _row(days[0], "2026.09E", "Q", op_krw=10), _row(days[-1], "2026.09E", "Q", op_krw=20)]  # Q 제외
+    s = fe.compute_revision(hist)["summary"]["4w"]
+    assert s == {"up": 0, "down": 1, "flat": 1, "n": 2, "basis": "op_krw"}
+
+
+def test_revision_is_a_known_bundle_and_in_all():
+    want, bad = fe.parse_bundles("revision")
+    assert want == {"revision"} and bad == []
+    assert "revision" in fe.parse_bundles("all")[0]


### PR DESCRIPTION
## 무엇
`forward_estimates_data`에 `bundle=revision` 추가 — "컨센서스가 오르고 있나"에 답한다.

## 데이터
`fwd_hist` (Supabase, 260904 신설): 슬림 18칸 · 추정 보유 종목의 전 기간 행 · 주 1회(토 18:30) · 13주 롤링. 현재 8/28~9/3 6일치 백필됨(61,118행, 17 MB). 로컬 DuckDB가 원본.

## 규칙
- 기준일 = 목표일(4w=28일·12w=91일) **이전의 가장 가까운 스냅샷**
- 이력이 목표일까지 안 닿으면 가장 오래된 스냅샷과 비교하고 **부분 비교**로 밝힌다 (없음 ≠ 짧음)
- % = (지금−기준)/|기준| — 적자→흑자는 상향. 기준 0/None 은 칸을 뺀다. 그때 없던 기간은 absent
- 방향 집계 = FY 추정 행 영업이익 기준 상향/하향/유지(±0.5%)
- `fwd_hist` 유무를 `to_regclass` 로 먼저 확인 (없는 표 질의 → 풀 60초 다운 방지)

## 검증
- pytest 1,475 passed (신규 9건 포함, 어휘 래칫 통과)
- 실DB(읽기 전용) 삼성전자: baselines 8/28(6일 전, 부분 비교) · FY 3기간 상향 2/유지 1 · md 렌더 정상

## 배포 후
main merge → deploy.yml → Fly. 첫 정식 4w 비교는 9/26(토) 이후 잡힌다.