### PR TITLE
feat(usage): 드레인 백업 CSV → parquet — 쓰기(events_drain)와 읽기(drained_columns)를 함께

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,10 @@ dependencies = [
 text = "LicenseRef-PolyForm-Noncommercial-1.0.0"
 
 [dependency-groups]
-dev = ["pytest>=8.0"]
+dev = [
+    "duckdb>=1.5.5",
+    "pytest>=8.0",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/drain_backlog_check.py
+++ b/scripts/drain_backlog_check.py
@@ -113,7 +113,7 @@ def main() -> int:
     print("\n⚠️  " + " · ".join(bad))
     print("""
 조치 (private 레포 백업이 먼저다 — 지우는 쪽만 영속이고 남기는 쪽이 휘발이면 백업이 아니다):
-  1) python3 scripts/events_drain.py                 # dry-run: CSV 만 쓴다
+  1) python3 scripts/events_drain.py                 # dry-run: parquet 만 쓴다(usage/events/)
   2) open-proxy-storage 에서 usage/*.csv 커밋·푸시
   3) python3 scripts/events_drain.py --apply         # 검증 후 DELETE
   4) VACUUM FULL ops_tool_calls;                   # 여기까지 해야 용량이 실제로 돌아온다

--- a/scripts/events_drain.py
+++ b/scripts/events_drain.py
@@ -1,30 +1,37 @@
 """events(사용량 텔레메트리) 주간 드레인 — Supabase(500MB 무료티어) 압박 완화, DB→별도 private 저장소.
 
 배경(260705): events가 6/29 사용 스파이크 이후 일 3천~7천건 유입, 이 페이스면 연 ~360MB 증가로
-krx_weekly(연 22MB)보다 16배 빠르게 무료티어를 채움. 완결된 과거 주(KST 월~일)를 CSV로 내보내고
+krx_weekly(연 22MB)보다 16배 빠르게 무료티어를 채움. 완결된 과거 주(KST 월~일)를 parquet 로 내보내고
 DB에서 삭제.
 
 **저장 위치(260705 변경)**: 유저 로그라 메인 레포(open-proxy-mcp)에도 wiki에도 안 두고, 별도 private
 레포 `MarcoYou/open-proxy-storage`(usage/ 폴더)에 둔다. 로컬 클론 경로는 기기마다 다를 수 있어
 `.env`의 `OPM_STORAGE_REPO`로 지정(미설정 시 `../open-proxy-storage` 기본값 — open-proxy-mcp와 형제
-디렉토리로 클론했다고 가정). 이 스크립트는 CSV만 그 폴더에 쓴다 — **git add/commit/push는 별도 수동**
+디렉토리로 클론했다고 가정). 이 스크립트는 parquet 만 그 폴더에 쓴다 — **git add/commit/push는 별도 수동**
 (또는 향후 자동화 스크립트로 확장).
 
-파일명: {주시작yymmdd}-{주끝mmdd}_user_log.csv (예: 260629-0705_user_log.csv)
+**저장 형식(260904 변경)**: CSV → **parquet** (`usage/events/{주시작yymmdd}-{주끝mmdd}.parquet`).
+사용량이 일 15,000콜로 늘어 CSV 는 주당 ~30MB·연 1.5GB 가 git 에 쌓일 판이었다. parquet(zstd)는
+같은 내용이 주당 ~1.5MB. 타입은 **Postgres 스키마에서 그대로 옮긴다** — CSV 로 한 번 내린 뒤
+`read_csv(columns=<PG 타입>)` 로 읽어 쓰므로 추론 오류가 없다. 읽을 땐 DuckDB 로
+`read_parquet('usage/events/*.parquet', union_by_name=true)` 한 줄이면 전 기간이 한 표다.
+(옛 CSV 8개는 `opm_events_all_260622-260904.parquet` 통합본과 events/ 주별 파일로 옮겼다.)
 
 **컬럼은 스키마에서 파생한다 (260810 — 이걸 안 해서 9컬럼이 지워질 뻔했다).**
 종전엔 7개를 손으로 적어두고 **행 전체를 DELETE** 했다. 그 사이 컬럼이 260802·260804·260810
 세 번 늘었는데(error_kind·response_bytes·doc_*·corp_codes·fetch_*·web_wait_ms) 드레인은 한 번도
 안 따라와, 돌리는 순간 **9컬럼이 백업 없이 영구 소멸**하는 상태였다. 다행히 아직 안 돌았다.
 이제 `information_schema` 에서 컬럼을 읽으므로 같은 드리프트가 구조적으로 불가능하고,
-**지우기 전에 CSV 를 되읽어 행수·헤더를 검증**한다(검증 실패 시 아무것도 안 지우고 중단).
+**지우기 전에 parquet 을 되읽어 행수·컬럼·고유 event_id 를 검증**한다(검증 실패 시 아무것도 안 지우고 중단).
 
 **진행 중인 현재 주(미완결)는 절대 안 건드림** — 완결된 과거 주만 대상.
 usage_tracker.py의 코호트 분석(예: "N일차 재방문율")은 raw events가 있어야 하므로, 드레인된 주의
-분석이 필요하면 해당 CSV를 다시 읽어들이는 방식으로(추후 확장, 지금은 export만).
+분석은 `usage_tracker.drained_columns()` 가 `usage/events/*.parquet` 를 DB 와 합류시켜 본다(260817·260904).
 
 기본 dry-run(내보내기만, 삭제 안 함). 실제 삭제는 --apply.
 실행: python3 scripts/events_drain.py [--apply]
+의존: duckdb — dev 그룹(`uv sync`). 서버 런타임 의존성 아님(Dockerfile 은 --no-dev). 이 모듈을
+      import 만 하는 쪽(usage_tracker·drain_backlog_check 의 경로·시계 상수)은 duckdb 없이도 되게 지연 import.
 """
 import csv
 import os
@@ -41,7 +48,15 @@ from psycopg import sql
 
 KST = timezone(timedelta(hours=9))
 STORAGE_REPO = Path(os.getenv("OPM_STORAGE_REPO") or (ROOT.parent / "open-proxy-storage"))
-OUT_DIR = STORAGE_REPO / "usage"
+OUT_DIR = STORAGE_REPO / "usage" / "events"
+
+# Postgres data_type → DuckDB 타입. 스키마에서 파생하므로 컬럼이 늘어도 여기만 보면 된다.
+_PG2DUCK = {
+    "text": "VARCHAR", "character varying": "VARCHAR", "json": "VARCHAR", "jsonb": "VARCHAR",
+    "bigint": "BIGINT", "integer": "INTEGER", "smallint": "SMALLINT",
+    "boolean": "BOOLEAN", "double precision": "DOUBLE", "real": "FLOAT", "numeric": "DOUBLE",
+    "date": "DATE", "timestamp without time zone": "TIMESTAMP", "timestamp with time zone": "TIMESTAMPTZ",
+}
 
 
 def _kst(ts_ns: int) -> datetime:
@@ -58,31 +73,50 @@ def _to_ns(dt: datetime) -> int:
     return int(dt.timestamp() * 1e9)
 
 
-def _table_columns(con) -> list[str]:
-    """테이블의 **실제** 컬럼을 순서대로 읽는다.
+def _table_columns(con) -> list[tuple[str, str]]:
+    """테이블의 **실제** (컬럼, PG 타입)을 순서대로 읽는다.
 
     하드코딩하면 컬럼이 늘 때 조용히 빠지고, 이 스크립트는 그 뒤에 행을 통째로 지운다 —
     즉 드리프트가 곧 **되돌릴 수 없는 데이터 손실**이 된다. 스키마에서 파생시키는 것이
     유일하게 안전한 방식이다."""
-    return [r[0] for r in con.execute(
-        "SELECT column_name FROM information_schema.columns "
+    return [(r[0], r[1]) for r in con.execute(
+        "SELECT column_name, data_type FROM information_schema.columns "
         "WHERE table_name = 'ops_tool_calls' ORDER BY ordinal_position").fetchall()]
 
 
-def _verify_backup(fpath: Path, cols: list[str], n_rows: int) -> bool:
+def _write_parquet(tmp_csv: Path, fpath: Path, cols: list[tuple[str, str]]) -> None:
+    """CSV(전송용 임시) → parquet. 타입은 PG 스키마에서 명시해 넘긴다 — 추론에 맡기면
+    빈칸이 많은 정수 컬럼이 DOUBLE 로 굳는다."""
+    import duckdb  # 지연 — 상수만 쓰는 import 경로는 duckdb 가 없어도 된다
+    duck = duckdb.connect()
+    types = ", ".join(f"'{n}': '{_PG2DUCK.get(t, 'VARCHAR')}'" for n, t in cols)
+    duck.execute(
+        f"COPY (SELECT * FROM read_csv('{tmp_csv.as_posix()}', header=true, "
+        f"columns={{{types}}}, nullstr='') ORDER BY ts_ns) "
+        f"TO '{fpath.as_posix()}' (FORMAT parquet, COMPRESSION zstd)")
+    duck.close()
+
+
+def _verify_backup(fpath: Path, cols: list[tuple[str, str]], n_rows: int) -> bool:
     """지우기 전에 **쓴 것을 되읽는다.** 「썼다」와 「제대로 썼다」는 다르다 —
     디스크가 차거나 쓰기가 반쯤 끊겨도 예외 없이 파일은 남는다."""
     try:
-        with open(fpath, newline="", encoding="utf-8") as f:
-            back = list(csv.reader(f))
-    except OSError as e:
+        import duckdb  # 지연 import (위와 같은 이유)
+        duck = duckdb.connect()
+        names = [r[0] for r in duck.execute(
+            f"DESCRIBE SELECT * FROM read_parquet('{fpath.as_posix()}')").fetchall()]
+        n_back, n_ids = duck.execute(
+            f"SELECT COUNT(*), COUNT(DISTINCT event_id) FROM read_parquet('{fpath.as_posix()}')").fetchone()
+        duck.close()
+    except Exception as e:  # duckdb.IOException 등 — 어떤 이유든 못 읽으면 지우지 않는다
         print(f"  ❌ 백업을 되읽지 못했다: {e}")
         return False
-    if not back or back[0] != cols:
-        print(f"  ❌ 헤더 불일치 — 기대 {len(cols)}컬럼, 파일 {len(back[0]) if back else 0}컬럼")
+    want = [n for n, _t in cols]
+    if names != want:
+        print(f"  ❌ 컬럼 불일치 — 기대 {len(want)}개, 파일 {len(names)}개")
         return False
-    if len(back) - 1 != n_rows:
-        print(f"  ❌ 행수 불일치 — DB {n_rows}건, 파일 {len(back) - 1}건")
+    if n_back != n_rows or n_ids != n_rows:
+        print(f"  ❌ 행수 불일치 — DB {n_rows}건, 파일 {n_back}건(고유 event_id {n_ids})")
         return False
     return True
 
@@ -106,13 +140,13 @@ def main(apply: bool) -> None:
         print("컬럼 목록을 못 읽었다 — 백업이 온전한지 보장할 수 없으므로 중단."); con.close(); return
 
     print(f"events 범위: {_kst(mn)} ~ {_kst(mx)} · mode={'APPLY' if apply else 'DRY-RUN'}")
-    print(f"백업 컬럼 {len(cols)}개(스키마 파생): {', '.join(cols)}")
+    print(f"백업 컬럼 {len(cols)}개(스키마 파생): {', '.join(n for n, _t in cols)}")
     if apply:
         # 지운 행은 CSV 에만 남는다. 지금 통계·덱은 **DB 만** 읽으므로, 드레인한 구간의
         # first_seen·코호트는 그 시점부터 보이지 않는다(장기 사용자가 「신규」로 재라벨된다).
         # 이건 컬럼 손실과 달리 복구는 되지만, 모르고 돌리면 지표가 조용히 틀어진다.
         print("⚠️  드레인한 주는 DB 에서 사라진다 — usage_tracker·트랙션덱은 DB 만 읽으므로\n"
-              "    그 구간의 first_seen·코호트가 안 보이게 된다(CSV 로는 남는다).")
+              "    그 구간의 first_seen·코호트가 안 보이게 된다(parquet 로는 남는다).")
     print()
 
     OUT_DIR.mkdir(parents=True, exist_ok=True)
@@ -123,19 +157,24 @@ def main(apply: bool) -> None:
         rows = con.execute(
             sql.SQL("SELECT {} FROM ops_tool_calls "
                     "WHERE ts_ns >= %s AND ts_ns < %s ORDER BY ts_ns").format(
-                sql.SQL(", ").join(map(sql.Identifier, cols))),
+                sql.SQL(", ").join(sql.Identifier(n) for n, _t in cols)),
             (_to_ns(w), _to_ns(w_end))
         ).fetchall()
         if not rows:
             w = w_end; continue
-        fname = f"{w.strftime('%y%m%d')}-{(w_end - timedelta(days=1)).strftime('%m%d')}_user_log.csv"
-        fpath = OUT_DIR / fname
-        with open(fpath, "w", newline="", encoding="utf-8") as f:
+        stem = f"{w.strftime('%y%m%d')}-{(w_end - timedelta(days=1)).strftime('%m%d')}"
+        fpath = OUT_DIR / f"{stem}.parquet"
+        tmp_csv = OUT_DIR / f".{stem}.tmp.csv"
+        with open(tmp_csv, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
-            writer.writerow(cols)
+            writer.writerow([n for n, _t in cols])
             writer.writerows(rows)
+        try:
+            _write_parquet(tmp_csv, fpath, cols)
+        finally:
+            tmp_csv.unlink(missing_ok=True)
         print(f"[{w.date()}~{(w_end - timedelta(days=1)).date()}] {len(rows)}건 "
-              f"× {len(cols)}컬럼 → {fpath.name}")
+              f"× {len(cols)}컬럼 → events/{fpath.name} ({fpath.stat().st_size / 1048576:.2f} MB)")
         if not _verify_backup(fpath, cols, len(rows)):
             print("  → 아무것도 지우지 않고 중단한다.")
             con.close()

--- a/scripts/usage_tracker.py
+++ b/scripts/usage_tracker.py
@@ -68,8 +68,8 @@ def _pg_conn():
     return psycopg.connect(DATABASE_URL, connect_timeout=15)
 
 
-# ── 드레인된 과거 주 합류 (260817) ──────────────────────────────────────────
-#: `events_drain.py` 가 완결 주를 CSV 로 내보내고 DB 에서 지운다. **DB 만 읽으면 지운 만큼
+# ── 드레인된 과거 주 합류 (260817 · 260904 parquet) ────────────────────────────
+#: `events_drain.py` 가 완결 주를 parquet 로 내보내고 DB 에서 지운다. **DB 만 읽으면 지운 만큼
 #: 과거가 통째로 사라진다** — 260817 실측: 7주를 드레인하자 362,994행이 5,511행이 되면서
 #: 오래 쓴 사용자가 전부 「신규」로 재라벨됐다. 백업은 있는데 되읽을 길이 없었다.
 #: 드레인은 앞으로도 계속 돌아야 하므로(무료티어 압박 + 사용자-기업 연결의 수명 상한)
@@ -83,9 +83,13 @@ except ImportError:                      # `import scripts.usage_tracker` 로 �
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     from events_drain import OUT_DIR as DRAINED_DIR
 
-#: `*_user_log.csv` 만 읽는다. 같은 폴더의 `260810_test-pollution_purged.csv` 는
-#: **일부러 걷어낸 테스트 오염**이라 되살리면 안 되고, `user_registry.csv` 는 이벤트가 아니다.
-DRAINED_GLOB = "*_user_log.csv"
+#: `usage/events/*.parquet` 만 읽는다(260904 CSV→parquet — 주당 30MB 가 1.5MB). 한 폴더 위
+#: `usage/` 에 있는 `opm_events_all_*.parquet`(통합 재생성본)·`*_purged.csv`(일부러 걷어낸 테스트
+#: 오염)·`user_registry.csv` 는 글로브 밖이다. **통합본을 events/ 안에 두면 전 기간이 두 번
+#: 세어진다** — 통합본은 산출물이고 정본은 주별 파일이다.
+DRAINED_GLOB = "*.parquet"
+#: parquet 은 PG 스키마 타입을 그대로 옮긴다(events_drain._PG2DUCK). 그래도 문자열로 들어온
+#: 정수·불리언이 있으면 여기서 고친다 — 하류 계산이 조용히 갈리는 쪽보다 낫다.
 _INT_COLS = {"ts_ns", "status", "latency_ms", "response_bytes", "doc_mem_hits",
              "doc_disk_hits", "doc_misses", "fetch_viewer", "fetch_kind", "web_wait_ms",
              "inflight", "cpu_ms", "lag_ms"}
@@ -124,7 +128,10 @@ def _db_event_ids() -> set:
             finally:
                 con.close()
         return {r[0] for r in db().execute(f"SELECT event_id FROM {tbl}").fetchall()}
-    except Exception:
+    except Exception as e:
+        # 빈 집합을 조용히 돌려주면 dry-run 드레인 구간이 **두 번 세어진다**. 계속 가되 알린다.
+        print(f"⚠️  DB event_id 를 못 읽었다({type(e).__name__}) — 드레인 백업과의 중복 제거 없이 합류한다.",
+              file=sys.stderr)
         return set()
 
 
@@ -132,59 +139,74 @@ _drained_cache: dict | None = None
 
 
 def drained_columns() -> dict:
-    """드레인 CSV → {컬럼명: [값, ...]} (열 지향 — 투영이 공짜고 메모리가 싸다).
+    """드레인 parquet → {컬럼명: [값, ...]} (열 지향 — 투영이 공짜고 메모리가 싸다).
 
+    DuckDB `read_parquet(..., union_by_name=true)` 로 읽는다 — 주마다 컬럼 수가 다르다
+    (260817 이전 23개 · 이후 21개처럼). **이름으로 맞춰야** 늦게 생긴 열이 옛 주에서 NULL 로
+    정렬되고, 위치로 맞추면 행이 밀린다(CSV 시절 `weak_kinds` 에서 실제로 깨졌다).
     문자열이 반복되는 열(key_hash 346개·tool 30여 개)은 **interning** 한다 —
-    안 하면 35만 행이 수백 MB 가 된다.
-    폴더·파일이 없으면 **조용히 넘어가지 않는다.** 그 침묵이 이 사고의 원인이었다.
+    안 하면 48만 행이 수백 MB 가 된다.
+    폴더·파일이 없으면 **조용히 넘어가지 않는다.** 그 침묵이 260817 사고의 원인이었다.
     """
     global _drained_cache
     if _drained_cache is not None:
         return _drained_cache
-    import csv as _csv
 
-    if not DRAINED_DIR.is_dir() or not sorted(DRAINED_DIR.glob(DRAINED_GLOB)):
+    files = sorted(DRAINED_DIR.glob(DRAINED_GLOB)) if DRAINED_DIR.is_dir() else []
+    if not files:
         print(f"⚠️  드레인 백업이 없다({DRAINED_DIR}/{DRAINED_GLOB}) — DB 구간만 집계한다.\n"
               f"    OPM_STORAGE_REPO 가 맞는지 확인. 과거 지표는 실제보다 작게 나온다.",
               file=sys.stderr)
         _drained_cache = {}
         return _drained_cache
+    import duckdb  # 서버 런타임 의존성 아님 — 통계 경로 전용(dev 그룹)
 
     have = _db_event_ids()
-    files = sorted(DRAINED_DIR.glob(DRAINED_GLOB))
-    # **헤더를 먼저 합집합으로 잡는다.** 컬럼은 260802·260804·260810·260817 로 계속 늘었고
-    # 백업은 스키마 파생이라 **주마다 헤더가 다르다**. 읽어 가면서 열을 추가하면 늦게 등장한
-    # 열만 짧아져 행이 밀린다 — 실제로 `weak_kinds`(260810 신설)에서 그렇게 깨졌다.
-    cols: dict[str, list] = {}
-    for f in files:
-        with open(f, newline="", encoding="utf-8") as fh:
-            for name in (_csv.DictReader(fh).fieldnames or []):
-                cols.setdefault(name, [])
-    pool: dict = {}
-    n = dup = 0
-    for f in files:
-        with open(f, newline="", encoding="utf-8") as fh:
-            rd = _csv.DictReader(fh)
-            for r in rd:
-                if r["event_id"] in have:
+    paths = "[" + ", ".join("'" + f.as_posix().replace("'", "''") + "'" for f in files) + "]"
+    duck = duckdb.connect()
+    try:
+        src = f"read_parquet({paths}, union_by_name=true)"
+        # TIMESTAMPTZ(ts_kst) 를 파이썬 datetime 으로 바꾸려면 duckdb 가 pytz 를 요구한다 —
+        # 통계는 전부 ts_ns(정수) 로 계산하므로 시각 열은 문자열로 받는다(의존성 하나 덜).
+        sel = ", ".join(
+            f'CAST("{n}" AS VARCHAR) AS "{n}"' if "TIMESTAMP" in t.upper() or "DATE" in t.upper() else f'"{n}"'
+            for n, t, *_ in duck.execute(f"DESCRIBE SELECT * FROM {src}").fetchall())
+        cur = duck.execute(f"SELECT {sel} FROM {src} ORDER BY ts_ns")
+        names = [d[0] for d in cur.description]
+        if "event_id" not in names:
+            raise SystemExit(f"드레인 parquet 에 event_id 열이 없다 — 중복 제거를 할 수 없어 멈춘다: {names}")
+        eid = names.index("event_id")
+        cols: dict[str, list] = {k: [] for k in names}
+        pool: dict = {}
+        n = dup = 0
+        while True:
+            chunk = cur.fetchmany(50_000)
+            if not chunk:
+                break
+            for r in chunk:
+                if r[eid] in have:
                     dup += 1
                     continue
-                for k, lst in cols.items():
-                    v = r.get(k) or ""
-                    if not v:
-                        lst.append(None)
-                    elif k in _INT_COLS:
-                        lst.append(int(v))
-                    elif k in _BOOL_COLS:
-                        lst.append(v == "True")
+                for k, v in zip(names, r):
+                    if v is None or v == "":
+                        cols[k].append(None)
+                    elif isinstance(v, str):
+                        if k in _INT_COLS:
+                            cols[k].append(int(v))
+                        elif k in _BOOL_COLS:
+                            cols[k].append(v in ("True", "true", "t", "1"))
+                        else:
+                            cols[k].append(pool.setdefault(v, v))    # interning
                     else:
-                        lst.append(pool.setdefault(v, v))    # interning
+                        cols[k].append(v)
                 n += 1
+    finally:
+        duck.close()
     # 열 길이가 하나라도 다르면 그 뒤 모든 투영이 밀린다 — 조용히 틀리느니 여기서 멈춘다.
     bad = {k: len(v) for k, v in cols.items() if len(v) != n}
     if bad:
         raise SystemExit(f"드레인 백업의 열 길이가 어긋난다(기대 {n:,}): {bad}")
-    print(f"  · 드레인 백업 {n:,}건 합류"
+    print(f"  · 드레인 백업 {n:,}건 합류({len(files)}주 parquet)"
           f"{f' (DB 와 겹쳐 제외 {dup:,})' if dup else ''}", file=sys.stderr)
     _drained_cache = cols
     return cols

--- a/tests/test_events_drain_guard.py
+++ b/tests/test_events_drain_guard.py
@@ -6,9 +6,12 @@
 corp_codes·fetch_*·web_wait_ms) 드레인은 한 번도 안 따라와, 돌리는 순간 9컬럼이
 **영구 소멸**하는 상태였다. 아직 안 돌아서 손실은 없었다.
 
+260904: 백업 형식이 CSV → parquet(zstd). 타입은 PG 스키마에서 명시해 넘긴다 — 추론에 맡기면
+빈칸 많은 정수 열이 DOUBLE 로 굳고, 되읽는 쪽이 int 를 기대하면 조용히 갈린다.
+
 이 파일이 지키는 것은 하나 — **지우기 전에 백업을 되읽어 온전한지 확인한다.**
 컬럼 목록은 이제 information_schema 에서 파생하므로, 누군가 다시 손으로 박아도
-헤더가 스키마와 어긋나 이 검증에서 걸린다(드리프트의 최종 방어선이기도 하다).
+컬럼이 스키마와 어긋나 이 검증에서 걸린다(드리프트의 최종 방어선이기도 하다).
 """
 from __future__ import annotations
 
@@ -19,6 +22,7 @@ from pathlib import Path
 import pytest
 
 psycopg = pytest.importorskip("psycopg")  # 드레인은 Postgres 전용
+duckdb = pytest.importorskip("duckdb")    # parquet 쓰기·되읽기 — dev 그룹
 
 _SRC = Path(__file__).resolve().parent.parent / "scripts" / "events_drain.py"
 
@@ -30,40 +34,68 @@ def _mod():
     return m
 
 
-def _write(path: Path, header, rows):
-    with path.open("w", newline="", encoding="utf-8") as f:
+def _write(m, path: Path, cols, rows):
+    """드레인과 **같은 경로**로 쓴다 — 임시 CSV → `_write_parquet`(PG 타입 명시)."""
+    tmp = path.with_suffix(".tmp.csv")
+    with tmp.open("w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)
-        w.writerow(header)
+        w.writerow([n for n, _t in cols])
         w.writerows(rows)
+    m._write_parquet(tmp, path, cols)
+    tmp.unlink()
 
 
-COLS = ["event_id", "ts_ns", "key_hash"]
+#: (컬럼, PG data_type) — `_table_columns` 가 information_schema 에서 주는 모양 그대로
+COLS = [("event_id", "text"), ("ts_ns", "bigint"), ("key_hash", "text")]
 ROWS = [("a", 1, "h1"), ("b", 2, "h2")]
 
 
 def test_intact_backup_passes(tmp_path):
-    p = tmp_path / "ok.csv"
-    _write(p, COLS, ROWS)
-    assert _mod()._verify_backup(p, COLS, len(ROWS)) is True
+    m = _mod()
+    p = tmp_path / "ok.parquet"
+    _write(m, p, COLS, ROWS)
+    assert m._verify_backup(p, COLS, len(ROWS)) is True
+
+
+def test_types_come_from_schema_not_inference(tmp_path):
+    """빈칸이 섞인 정수 열도 BIGINT 로 남아야 한다 — 추론이면 DOUBLE 이 된다."""
+    m = _mod()
+    p = tmp_path / "typed.parquet"
+    cols = COLS + [("latency_ms", "bigint"), ("is_error", "boolean")]
+    _write(m, p, cols, [("a", 1, "h1", "", "t"), ("b", 2, "h2", 7, "f")])
+    types = {r[0]: r[1] for r in duckdb.sql(f"DESCRIBE SELECT * FROM read_parquet('{p.as_posix()}')").fetchall()}
+    assert types["ts_ns"] == "BIGINT" and types["latency_ms"] == "BIGINT" and types["is_error"] == "BOOLEAN"
+    rows = duckdb.sql(f"SELECT latency_ms, is_error FROM read_parquet('{p.as_posix()}') ORDER BY ts_ns").fetchall()
+    assert rows == [(None, True), (7, False)]
 
 
 def test_missing_columns_is_rejected(tmp_path):
     """**이게 260810 의 실제 상태다.** 스키마엔 17컬럼인데 7개만 적고 지우려 했다."""
-    p = tmp_path / "short.csv"
-    _write(p, COLS[:2], [r[:2] for r in ROWS])
-    assert _mod()._verify_backup(p, COLS, len(ROWS)) is False, (
+    m = _mod()
+    p = tmp_path / "short.parquet"
+    _write(m, p, COLS[:2], [r[:2] for r in ROWS])
+    assert m._verify_backup(p, COLS, len(ROWS)) is False, (
         "컬럼이 빠진 백업을 통과시켰다 — 이 상태로 DELETE 하면 영구 소멸이다")
 
 
 def test_truncated_backup_is_rejected(tmp_path):
     """쓰기가 반쯤 끊겨도 파일은 남는다. 「썼다」와 「제대로 썼다」는 다르다."""
-    p = tmp_path / "trunc.csv"
-    _write(p, COLS, ROWS[:1])
-    assert _mod()._verify_backup(p, COLS, len(ROWS)) is False
+    m = _mod()
+    p = tmp_path / "trunc.parquet"
+    _write(m, p, COLS, ROWS[:1])
+    assert m._verify_backup(p, COLS, len(ROWS)) is False
+
+
+def test_duplicated_event_ids_are_rejected(tmp_path):
+    """행수는 맞는데 event_id 가 겹치면 — 되읽을 때 중복 제거로 한 건이 사라진다. 지우면 안 된다."""
+    m = _mod()
+    p = tmp_path / "dup.parquet"
+    _write(m, p, COLS, [("a", 1, "h1"), ("a", 2, "h2")])
+    assert m._verify_backup(p, COLS, 2) is False
 
 
 def test_unreadable_backup_is_rejected(tmp_path):
-    assert _mod()._verify_backup(tmp_path / "없음.csv", COLS, 1) is False
+    assert _mod()._verify_backup(tmp_path / "없음.parquet", COLS, 1) is False
 
 
 def test_columns_are_derived_not_hardcoded():
@@ -75,3 +107,18 @@ def test_columns_are_derived_not_hardcoded():
     assert "information_schema.columns" in src
     assert '"SELECT event_id, ts_ns, key_hash, status, tool, latency_ms, is_error' not in src, (
         "옛 하드코딩 SELECT 가 되살아났다")
+
+
+def test_module_imports_without_duckdb(monkeypatch):
+    """usage_tracker·drain_backlog_check 는 이 모듈의 **경로·시계 상수만** 가져온다 —
+    duckdb 가 없는 환경(서버 이미지는 --no-dev)에서도 import 는 되어야 한다."""
+    import builtins
+    real = builtins.__import__
+
+    def fake(name, *a, **k):
+        if name == "duckdb":
+            raise ImportError("no duckdb")
+        return real(name, *a, **k)
+    monkeypatch.setattr(builtins, "__import__", fake)
+    m = _mod()
+    assert m.OUT_DIR.name == "events" and m.OUT_DIR.parent.name == "usage"

--- a/tests/test_trading_data.py
+++ b/tests/test_trading_data.py
@@ -63,6 +63,7 @@ def test_tool_alias_folds_old_name():
 def test_merge_drained_folds_tool_column():
     """DB 행과 드레인 행이 **같은 함수**를 지나므로 접기는 한 곳이면 된다."""
     u = _load_script("usage_tracker")
+    u._drained_cache = {}   # 실제 드레인 parquet·DB 를 건드리지 않는다(network 0콜) — 접기만 본다
     rows = [("valuation", "h1", 10, 0), ("company", "h2", 5, 0)]
     got = [r[0] for r in u.merge_drained(rows, u._TL_COLS)][:2]
     assert got == ["price_multiple_data", "company"]

--- a/tests/test_usage_drained_merge.py
+++ b/tests/test_usage_drained_merge.py
@@ -6,36 +6,64 @@
 전부 「신규」로 재라벨됐고, 드레인 스크립트는 이 부작용을 경고까지 하고 있었다 —
 경고만 있고 합류 지점이 없었다. 백업이 아니라 무덤이었다.
 
+260904: 백업 형식이 CSV → parquet(`usage/events/{주}.parquet`) 로 바뀌었다. 읽는 쪽이 같이
+안 바뀌면 **글로브가 0건이라 위 사고가 조용히 재현된다** — 이 파일이 그걸 막는다.
+
 여기서 지키는 것은 「읽는다」가 아니라 **「읽되 어긋나지 않는다」**이다:
-  · 주마다 헤더가 다르다(컬럼이 260802·260804·260810·260817 로 늘었다). 헤더를 합집합으로
-    먼저 안 잡으면 늦게 생긴 열만 짧아져 **행이 통째로 밀린다**(실측: weak_kinds 에서 깨졌다)
+  · 주마다 컬럼 수가 다르다(260802·260804·260810·260817 로 늘었고, 실제 parquet 도 21/23 컬럼이
+    섞여 있다). 이름으로 합치지 않으면 늦게 생긴 열만 짧아져 **행이 통째로 밀린다**
   · 투영 순서가 SELECT 순서와 달라지면 값이 **조용히 다른 컬럼으로** 들어간다
     (260704 mkt_fund_hist 사고와 같은 실패 모드 — 에러가 안 나서 더 위험하다)
+  · 통합 재생성본(`usage/opm_events_all_*.parquet`)이 주별 폴더에 섞이면 **두 번 세어진다**
 """
 from __future__ import annotations
 
-import csv
 import importlib
 import sys
 from pathlib import Path
 
 import pytest
 
+duckdb = pytest.importorskip("duckdb")  # dev 그룹 — 서버 런타임 의존성이 아니다
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 
 @pytest.fixture
 def ut(tmp_path, monkeypatch):
-    """usage_tracker 를 임시 백업 폴더에 물려 놓는다. DB 는 안 쓴다."""
+    """usage_tracker 를 임시 백업 폴더(`<tmp>/events`)에 물려 놓는다. DB 는 안 쓴다."""
     monkeypatch.delenv("DATABASE_URL", raising=False)
     mod = importlib.reload(importlib.import_module("usage_tracker"))
-    monkeypatch.setattr(mod, "DRAINED_DIR", tmp_path)
+    (tmp_path / "events").mkdir()
+    monkeypatch.setattr(mod, "DRAINED_DIR", tmp_path / "events")
     monkeypatch.setattr(mod, "_drained_cache", None)
     monkeypatch.setattr(mod, "_db_event_ids", lambda: set())
     return mod
 
 
 def _write(path: Path, cols, rows):
+    """실제 드레인처럼 **타입이 있는** parquet 을 쓴다(값은 파이썬 타입 그대로)."""
+    con = duckdb.connect()
+    marks = ", ".join(["?"] * len(cols))
+    con.execute(f"CREATE TABLE t ({', '.join(f'{c} {_duck_type(cols, c, rows)}' for c in cols)})")
+    for r in rows:
+        con.execute(f"INSERT INTO t VALUES ({marks})", list(r))
+    con.execute(f"COPY (SELECT * FROM t ORDER BY ts_ns) TO '{path.as_posix()}' (FORMAT parquet)")
+    con.close()
+
+
+def _duck_type(cols, c, rows):
+    i = cols.index(c)
+    sample = next((r[i] for r in rows if r[i] is not None), None)
+    if isinstance(sample, bool):
+        return "BOOLEAN"
+    if isinstance(sample, int):
+        return "BIGINT"
+    return "VARCHAR"
+
+
+def _write_csv(path: Path, cols, rows):
+    import csv
     with open(path, "w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)
         w.writerow(cols)
@@ -44,48 +72,60 @@ def _write(path: Path, cols, rows):
 
 def test_headers_differ_across_weeks_and_rows_still_line_up(ut, tmp_path):
     """**핵심.** 옛 주에는 없던 컬럼이 새 주에 생긴다 — 그래도 행이 밀리면 안 된다."""
-    _write(tmp_path / "260601-0607_user_log.csv",
+    ev = tmp_path / "events"
+    _write(ev / "260601-0607.parquet",
            ["event_id", "ts_ns", "key_hash", "tool", "latency_ms", "is_error"],
-           [["e1", 1000, "hA", "treasury_share", 11, "False"],
-            ["e2", 2000, "hB", "company", 22, "True"]])
+           [["e1", 1000, "hA", "treasury_share", 11, False],
+            ["e2", 2000, "hB", "company", 22, True]])
     # 다음 주에 weak_kinds 가 생겼다(260810 실제 사례)
-    _write(tmp_path / "260608-0614_user_log.csv",
+    _write(ev / "260608-0614.parquet",
            ["event_id", "ts_ns", "key_hash", "tool", "latency_ms", "is_error", "weak_kinds"],
-           [["e3", 3000, "hC", "valuation", 33, "", "fuzzy"]])
+           [["e3", 3000, "hC", "valuation", 33, None, "fuzzy"]])
 
     d = ut.drained_columns()
     assert len({len(v) for v in d.values()}) == 1, f"열 길이가 어긋났다: {[(k, len(v)) for k, v in d.items()]}"
     assert len(d["ts_ns"]) == 3
     # 옛 주는 그 열을 **가진 적이 없다** — 0 이 아니라 None 이 맞다.
     assert d["weak_kinds"] == [None, None, "fuzzy"]
+    assert d["is_error"] == [False, True, None]
 
 
 def test_projection_follows_the_select_order(ut, tmp_path):
     """투영은 SELECT 순서를 그대로 따라야 한다 — 어긋나면 에러 없이 값만 뒤바뀐다."""
-    _write(tmp_path / "260601-0607_user_log.csv",
+    _write(tmp_path / "events" / "260601-0607.parquet",
            ["event_id", "ts_ns", "key_hash", "tool", "latency_ms", "is_error"],
-           [["e1", 1000, "hA", "treasury_share", 11, "False"]])
+           [["e1", 1000, "hA", "treasury_share", 11, False]])
 
     assert ut.merge_drained([], ("tool", "key_hash", "latency_ms", "is_error")) == \
         [("treasury_share", "hA", 11, False)]
     # 순서를 바꾸면 결과도 바뀐다 — 이 대조가 있어야 위 단언이 우연이 아니다.
     assert ut.merge_drained([], ("key_hash", "tool")) == [("hA", "treasury_share")]
-    # 타입도 맞아야 한다. CSV 는 전부 문자열이라 안 고치면 하류 계산이 조용히 갈린다.
+    # 타입도 맞아야 한다. parquet 은 타입을 지니지만, 문자열로 굳은 주가 섞여도 하류가 갈리면 안 된다.
     (tool, kh, lat, err), = ut.merge_drained([], ("tool", "key_hash", "latency_ms", "is_error"))
     assert isinstance(lat, int) and err is False
 
 
+def test_stringly_typed_week_is_normalised(ut, tmp_path):
+    """타입 없이 VARCHAR 로 굳은 주(옛 CSV 를 옮긴 것 등)도 int/bool 로 돌려놓는다."""
+    _write(tmp_path / "events" / "260601-0607.parquet",
+           ["event_id", "ts_ns", "key_hash", "latency_ms", "is_error"],
+           [["e1", 1000, "hA", "11", "True"], ["e2", 2000, "hB", "", ""]])
+    d = ut.drained_columns()
+    assert d["latency_ms"] == [11, None] and d["is_error"] == [True, None]
+
+
 def test_db_rows_come_first_and_are_untouched(ut, tmp_path):
-    _write(tmp_path / "260601-0607_user_log.csv",
+    _write(tmp_path / "events" / "260601-0607.parquet",
            ["event_id", "ts_ns", "key_hash"], [["e1", 1000, "hA"]])
     out = ut.merge_drained([(9999, "hDB")], ("ts_ns", "key_hash"))
     assert out == [(9999, "hDB"), (1000, "hA")]
 
 
 def test_rows_already_in_the_db_are_not_counted_twice(ut, tmp_path, monkeypatch):
-    """드레인은 내보낸 뒤 지우니 원래 안 겹친다. **중단·재실행이면 겹친다** —
-    겹침을 가정하지 않는 쪽이 위험하다(모든 지표가 부풀어도 아무도 모른다)."""
-    _write(tmp_path / "260601-0607_user_log.csv",
+    """드레인은 내보낸 뒤 지우니 원래 안 겹친다. **dry-run 이었거나 중단·재실행이면 겹친다** —
+    겹침을 가정하지 않는 쪽이 위험하다(모든 지표가 부풀어도 아무도 모른다).
+    실측 260904: 8/17~8/30 두 주가 parquet 과 DB 양쪽에 있었다."""
+    _write(tmp_path / "events" / "260601-0607.parquet",
            ["event_id", "ts_ns", "key_hash"], [["e1", 1000, "hA"], ["e2", 2000, "hB"]])
     monkeypatch.setattr(ut, "_db_event_ids", lambda: {"e1"})
     monkeypatch.setattr(ut, "_drained_cache", None)
@@ -93,18 +133,26 @@ def test_rows_already_in_the_db_are_not_counted_twice(ut, tmp_path, monkeypatch)
 
 
 def test_missing_backup_is_loud_not_silent(ut, tmp_path, capsys):
-    """**조용한 빈 결과가 이 사고의 원인이었다.** 없으면 반드시 경고한다."""
+    """**조용한 빈 결과가 이 사고의 원인이었다.** 없으면 반드시 경고한다 — 폴더가 비었든 없든."""
+    assert ut.drained_columns() == {}
+    assert "드레인 백업이 없다" in capsys.readouterr().err
+    ut._drained_cache = None
+    ut.DRAINED_DIR = tmp_path / "없는폴더"
     assert ut.drained_columns() == {}
     assert "드레인 백업이 없다" in capsys.readouterr().err
 
 
-def test_only_user_log_files_are_read(ut, tmp_path):
-    """같은 폴더의 `*_purged.csv` 는 **일부러 걷어낸 테스트 오염**이라 되살리면 안 된다."""
-    _write(tmp_path / "260601-0607_user_log.csv",
+def test_only_weekly_parquet_files_are_read(ut, tmp_path):
+    """`usage/events/*.parquet` 만. 한 폴더 위의 `opm_events_all_*.parquet`(통합 재생성본)은
+    **같은 이벤트의 사본**이라 읽으면 두 번 세어지고, `*_purged.csv` 는 **일부러 걷어낸 테스트
+    오염**이라 되살리면 안 되며, `user_registry.csv` 는 이벤트가 아니다."""
+    ev = tmp_path / "events"
+    _write(ev / "260601-0607.parquet", ["event_id", "ts_ns", "key_hash"], [["e1", 1000, "hA"]])
+    _write(tmp_path / "opm_events_all_260601-260607.parquet",
            ["event_id", "ts_ns", "key_hash"], [["e1", 1000, "hA"]])
-    _write(tmp_path / "260810_test-pollution_purged.csv",
-           ["event_id", "ts_ns", "key_hash"], [["bad", 1, "hPollution"]])
-    _write(tmp_path / "user_registry.csv", ["key_hash", "note"], [["hA", "x"]])
+    _write_csv(ev / "260810_test-pollution_purged.csv",
+               ["event_id", "ts_ns", "key_hash"], [["bad", 1, "hPollution"]])
+    _write_csv(tmp_path / "user_registry.csv", ["key_hash", "note"], [["hA", "x"]])
     assert ut.merge_drained([], ("key_hash",)) == [("hA",)]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -237,11 +237,53 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/19/e57151753576373c6696a12022648546cca6038e8833fda2908ee2342d9b/duckdb-1.5.5.tar.gz", hash = "sha256:72f33ee57ca7595b23957671a2cc7f7fe2be0ecc2d68f63abedcfcaa3a5c1238", size = 18066741, upload-time = "2026-07-22T10:55:17.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/d4/298acf9331a80b3ce6ac64dd940e7e13f4058fb69d18914445f02e3c7bfe/duckdb-1.5.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3b805507f88171b428b21c966c30e9a3d54e30b24528918a44ed0032542bc26f", size = 32702934, upload-time = "2026-07-22T10:53:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/90/c489fb63d64b2e7ee109ce8460bdede003a0f256e5b41a03a2a1c4764058/duckdb-1.5.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b08e19cc856220d8a26fa62abc2264b349aff67255e9373c6a3f607addd56dc6", size = 17343604, upload-time = "2026-07-22T10:53:22.767Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/27/effa80a15b1f0c61c235622f797868485359e8c9ad6a8e358e7a0c479151/duckdb-1.5.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a17e6a922e42a5c06ed2353fe78c5dff2610f6632d603836f9606ad0bf754079", size = 15488179, upload-time = "2026-07-22T10:53:25.945Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/07/21212345c8d24ba62dceaa20be3b21f5c46f1510b1b42ce93bb058afe0c4/duckdb-1.5.5-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bdc38922c365c37720149f90d90b1e9823eb82dad6830855b5f87537fa6fc0c", size = 19367323, upload-time = "2026-07-22T10:53:30.23Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d0/10371ae875fb4b5ef61bb892743b4b2e90c512b371fdf29317deb744857d/duckdb-1.5.5-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e238060db5ca59879882a6e9b015e2c65d5c64ddf281ba1d7a9a2033764152cf", size = 21476568, upload-time = "2026-07-22T10:53:33.486Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/35/09568ce617dd7bc0757b3d7b6a981660b9e4f0b7594de8ed776755eae740/duckdb-1.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:4acc72798ba1885a9c17d1242903d2cd502f13b1271c7677f7cab25d8578eceb", size = 13156129, upload-time = "2026-07-22T10:53:37.55Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c2/b62ec24d57bb8df4e24b0b58f7f8facb32f5fdb9f1895aed9e9fcdded168/duckdb-1.5.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1b543841b0ae18a9c982345cfa3987e9c065d3a4b0f067daa473d92d1e65f528", size = 32708371, upload-time = "2026-07-22T10:53:41.642Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ce/769171ba45f0b73632dc3bc3108d891e81dd6c6bbfba630a34a75b4dcc0f/duckdb-1.5.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a925d06c2a4c3b64553d6cc1aced5028d376d4479bed689a7d47e9b1dccd80a", size = 17343979, upload-time = "2026-07-22T10:53:44.951Z" },
+    { url = "https://files.pythonhosted.org/packages/46/59/a8e3384ee916e00d5dcf985194c1511d61978540778a1e96fa47f9fb3e0d/duckdb-1.5.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0c42757cb34722144bd4dfb94b6f336339e7b2468f6813fa7fa9a319ba07bab4", size = 15493704, upload-time = "2026-07-22T10:53:47.912Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1d/9840179c2607b90523a2884a129c4d4e6dbdc1178ba62a976c1043beba88/duckdb-1.5.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e72f9e1a4f90a5c8483ad4d540e495bf0834ba61c360b52499a573d7ed62a3f", size = 19366574, upload-time = "2026-07-22T10:53:51.876Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/55/f9641a4eebcc2f4df631287d6c3b9ed2eea3b92644f93acbad825e3972b6/duckdb-1.5.5-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9b6f86ed85d4ef5e0211eaebf75d057bd8bb520bba438a95dd0f4e42234bbfe", size = 21477952, upload-time = "2026-07-22T10:53:55.575Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/3a/07c3556e37a5c97b95917b029c8fdde4a25fbd76a660bacdac195cf20dcb/duckdb-1.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:9f4287f97ccf0c1f3d471e7115be2b067cbf99627e2d34bffd462dd64703cddc", size = 13156986, upload-time = "2026-07-22T10:53:58.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ff/07b48eef2078ca033847e9caa46cc7633b714c5f91ad1ce091c8ca89d792/duckdb-1.5.5-cp311-cp311-win_arm64.whl", hash = "sha256:179633a3fc6296c75d57c69c1e239fa9e5cdcb670fd1dbff88a02663f932905c", size = 14001317, upload-time = "2026-07-22T10:54:01.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/40/2e05d324400fdaa5656c9f48d6298da421cb034d85e509fa0e6e325cf04b/duckdb-1.5.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d4dd65f8941a604b947e0b9b4b4f7165988e29a23ec0b69b4038520956d9933e", size = 32753858, upload-time = "2026-07-22T10:54:05.514Z" },
+    { url = "https://files.pythonhosted.org/packages/79/15/5ceb58ffb5bb8a62b3fd7abb39c41467cdf94850ece02e6d88664dfc75ce/duckdb-1.5.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33db46679b071f108d57139493dee2d37e1f5efcf5c5c039c2969eed11a6c8a7", size = 17368293, upload-time = "2026-07-22T10:54:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/5c/bf02da0b354fe83cca4f95a4fbf762181af466f7d551ab2a093f7698882a/duckdb-1.5.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f0b88535a5d86fdd63dba6ea02ab68c003dfb9e4892b11256ef24c4da208baae", size = 15509131, upload-time = "2026-07-22T10:54:12.228Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a9/5f1f09da421d8e930e0b063d11c1b3f90363f40ede74438cd188afdd13a2/duckdb-1.5.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f316eae2323d9a851883fdf2dee91c1f9efe251ab33e14a2272f82a913422ed6", size = 19391959, upload-time = "2026-07-22T10:54:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/98/6549769f158126fa64fd6c1ac2eb59a18282146c939867a3eb31b7c1db07/duckdb-1.5.5-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a6d2d11859d82a936ebdcb30ce3d8a1cbb3e990bff05c12abb9b54c44fa7bd1", size = 21510909, upload-time = "2026-07-22T10:54:19.681Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b7/5753b41d3124838f868f9f523362812d9fc45409e9e4dd70dcbb0a25826e/duckdb-1.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:ddfbdb096c11d51ee22492397d342c90a82e62c5d09961477895934d0a25372f", size = 13168544, upload-time = "2026-07-22T10:54:22.789Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/28/44b679c7d46245f8398feae7edac959d1b83d4eb143e25b3fce0630b78bd/duckdb-1.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:2725d2b9ace3a4e75d72fc5a239f6a44b502c580edadb8fb2676db772c5f9282", size = 13988684, upload-time = "2026-07-22T10:54:26.003Z" },
+    { url = "https://files.pythonhosted.org/packages/47/37/4a38116e7700720fd152c666292214fd3abdf916496991296d8d1f66efbf/duckdb-1.5.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd98829b67788609017e65c761bd42a5dd0f9129441bed8bda4d6881ccf819f0", size = 32754294, upload-time = "2026-07-22T10:54:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/7d392f1ba1eee0eaf4ab4c8c7a604bfe3536cd63f979cf5c98798664f807/duckdb-1.5.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:feead93c56679b79592d437c62975d39cb67adedffa7592c763baf8160ac7366", size = 17368211, upload-time = "2026-07-22T10:54:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a5/0a6f4fa60562faa615e55e15bd1953a2f2b17a8edd8105e5cda215e43457/duckdb-1.5.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:49c963d9469373d7aba8d750d9ea565ab823e94166efed953f184dd9b169b98c", size = 15509136, upload-time = "2026-07-22T10:54:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/023c89f51978545b9fab318581bba0c457a58e7530d2d933e54ae7d8647c/duckdb-1.5.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a736217825461732b5442d05a220f3da2e23a0dae114efbf08c9bf171b53098a", size = 19392147, upload-time = "2026-07-22T10:54:39.551Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c5/41bef391fb8b23dbc133c9f2ba016e7a7a8124513d2cc1b430f1897d87e4/duckdb-1.5.5-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:078e6a60dd8eedde5832f45422ca5c4a6b8c837aeabd8a56ca0b7d933f588053", size = 21511060, upload-time = "2026-07-22T10:54:42.788Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9f/c44dfc1f924ac29b3252dc1b91393c01d009dbfe9f8ed33f10b986151bd1/duckdb-1.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:6826504277dba513c0c5d71d828456c94d729c9d2482f94b2e289f90a9167e28", size = 13168028, upload-time = "2026-07-22T10:54:46.127Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/591384b2cd59abddd6f5dc175e60374f9abae6064429f0c4402854c10f44/duckdb-1.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:baa9c5702002fabb559ded2a39008f9f421fcbc7237d388b8213eff1e08858de", size = 13989955, upload-time = "2026-07-22T10:54:49.262Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/56/12c65bfa2d2605b81981b264788891bcf11ec72227889554cead5d8d13b9/duckdb-1.5.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8e6413dd40facb7b8ab21bd844450cd8f549b29e138635be9cf090ef4d2049e2", size = 32761946, upload-time = "2026-07-22T10:54:53.412Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/46/682ce155f17e0d2822d4f13ee3db9ca4b5b7c2da61b841b2629035e1f4bc/duckdb-1.5.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:64078acfd16541132ac6e191eb81b2845554444a0305cc1aa581ba107e514aa8", size = 17375069, upload-time = "2026-07-22T10:54:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ce/a24bcbd3289c8f305a430759c5fc12242740b4af3e17f7593f3a34e333d2/duckdb-1.5.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c11775cc99a447618d5f1840126db17f2652f3eae05529df4f81f40e2df7151", size = 15519791, upload-time = "2026-07-22T10:55:00.681Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/76/3a01afbc615c1d418c0de58a6b68ac5ce2a8563232c0464bfbc2ce552398/duckdb-1.5.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77bbc1e6ba12e1e06f9020117bdf848627ecfdf36f907550e62e008e6109dece", size = 19398251, upload-time = "2026-07-22T10:55:04.168Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/43/3a5e81d1728f4d234c79bfe385808ee7c04834f7c37a4b5c257459c25614/duckdb-1.5.5-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fbf0f2d48b43c6c304d00463b463c27ead6c4b01c3c1816b750f728decf71afe", size = 21513851, upload-time = "2026-07-22T10:55:07.864Z" },
+    { url = "https://files.pythonhosted.org/packages/91/41/fc7c829172c60ca22485251eab285f4f1a0d87b486a024c726f21471d86e/duckdb-1.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:9dc826c4b50e64f6c4e4d07a3a9cb075ef70ba3899dc43ec5493dc3d7b04b353", size = 13691858, upload-time = "2026-07-22T10:55:11.181Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2c/95d9216b79e9273689d7ebce125a54503ed0c9bd7da931f0265888e99779/duckdb-1.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:63e48d4b74b15aeacd688976432a7225163df8c226eddeb8536bba2d4d4ff433", size = 14470180, upload-time = "2026-07-22T10:55:14.445Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -809,6 +851,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "duckdb" },
     { name = "pytest" },
 ]
 
@@ -824,7 +867,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.0" }]
+dev = [
+    { name = "duckdb", specifier = ">=1.5.5" },
+    { name = "pytest", specifier = ">=8.0" },
+]
 
 [[package]]
 name = "opentelemetry-api"


### PR DESCRIPTION
## 무엇을 바꿨나

**배경.** 드레인 백업 데이터는 260904 에 CSV → parquet(`open-proxy-storage/usage/events/*.parquet`)로 옮겨졌는데, 그걸 쓰는 코드는 다른 클론(beta-proxy-mcp)에 미커밋이었고 정본의 읽는 코드는 옛 `*_user_log.csv` 글로브였다. 글로브가 0건이면 통계·트랙션 덱이 진행 중인 주만 보는 **260817 사고가 조용히 재현**된다 — 실제로 그 상태였다.

- **`scripts/events_drain.py`**: 완결 주를 `usage/events/{주}.parquet`(zstd)로 쓴다. 타입은 PG 스키마에서 명시(`_PG2DUCK` — 추론이면 빈칸 많은 정수 열이 DOUBLE 로 굳는다). 되읽기 검증에 고유 `event_id` 추가. `duckdb` 는 지연 import — 경로·시계 상수만 가져오는 `usage_tracker`·`drain_backlog_check` 는 duckdb 없이도 import 된다.
- **`scripts/usage_tracker.py`** `drained_columns()`: `read_parquet(events/*.parquet, union_by_name=true)`. 주마다 컬럼 수가 다르므로(8/17 이후 21, 이전 23) 이름으로 합친다. TIMESTAMPTZ 열은 VARCHAR 로 받아 pytz 의존을 피한다. `_db_event_ids` 실패를 조용히 삼키지 않고 stderr 로 알린다(빈 집합이면 이중 계상).
- **tests**: 드레인 합류·가드 테스트를 parquet 픽스처로. 통합본이 `events/` 밖이면 안 읽히는 것, 문자열로 굳은 주의 정규화, duckdb 없는 import, `event_id` 중복 거부를 추가. `test_trading_data` 는 실제 드레인 폴더를 건드리지 않게 격리(network 0콜 유지).
- **pyproject**: `duckdb` 를 dev 그룹에. 서버 이미지는 `--no-dev` 라 안 들어간다. CI(`uv sync --dev`)·drain-backlog 워크플로(`uv sync`)는 받는다.

## 리뷰어가 알아야 할 것

| 검증 | 결과 |
|---|---|
| `uv run pytest -q` | 1470 passed (rebase 후 드레인 관련 3파일 재확인) |
| 실데이터 합류 | 10주 479,709건 · 1.3s · 23열 |
| DB 와 중복 | 0건 — DB 는 8/31 이후만 남아 있다(드레인 `--apply` 완료 상태) |

- 짝이 되는 storage 쪽 변경(`view_logs.py`·`export_all_events.py`·배치 규칙 문서·덱 스킬 최신본 복구)은 MarcoYou/open-proxy-storage#2.
- beta-proxy-mcp 클론의 `scripts/events_drain.py` 미커밋 변경은 이 PR 에 이식된 것이라 버려도 된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)