### PR TITLE
항 단위 시행 게이트: SSOT 조항을 조문번호로 직접 맞춰 표지

### DIFF
--- a/open_proxy_mcp/data/laws/law_provisions.json
+++ b/open_proxy_mcp/data/laws/law_provisions.json
@@ -18,7 +18,8 @@
     "table_applies_to": "md 표 '적용 대상' 열 원문(자동생성).",
     "gate_dates": "엔진 룰 applies_after가 가질 수 있는 날짜 집합(통과·공포·시행). lint[7c]가 layer별로 더 좁게 검사(A2=시행일/A1=공포·시행).",
     "notes": "부가 설명.",
-    "threshold_decree": "자산·자본금 임계를 실제로 정하는 대통령령(상법 시행령) 조문. 임계는 법이 아니라 시행령이 정하므로(예: '자산 2조'=시행령 §33) 출처를 명시. 없으면 null(임계 없는 모든 상장사/회사 적용)."
+    "threshold_decree": "자산·자본금 임계를 실제로 정하는 대통령령(상법 시행령) 조문. 임계는 법이 아니라 시행령이 정하므로(예: '자산 2조'=시행령 §33) 출처를 명시. 없으면 null(임계 없는 모든 상장사/회사 적용).",
+    "paragraphs": "이 개정이 실제로 손댄 항(paragraph) 번호 배열. article 에 '제N항'이 있으면 그 항, 없고 이 배열도 null 이면 조문 전체. law_lookup 이 as_of 기준 시행예정·유예 중인 항을 항 단위로 표시하는 데 쓴다(260903). 원문 <개정 YYYY.M.D> 마커로 대조."
   },
   "provisions": [
     {
@@ -41,6 +42,7 @@
         }
       ],
       "threshold_decree": null,
+      "paragraphs": null,
       "sanction_scope": null,
       "table_content": "이사 충실의무 (회사+주주 양방향)",
       "table_applies_to": "모든 상장사",
@@ -69,6 +71,7 @@
         }
       ],
       "threshold_decree": null,
+      "paragraphs": null,
       "sanction_scope": null,
       "table_content": "사외이사 → 독립이사 명칭 변경",
       "table_applies_to": "모든 상장사 (공포+1년 유예)",
@@ -98,6 +101,7 @@
         }
       ],
       "threshold_decree": null,
+      "paragraphs": null,
       "sanction_scope": null,
       "table_content": "독립이사 의무선임 비율 1/3",
       "table_applies_to": "모든 상장사 (시행+1년 유예)",
@@ -133,6 +137,7 @@
         }
       ],
       "threshold_decree": "상법 시행령 §37①(감사위 의무설치·자산 2조+)·§36(자산총액 1천억+ 상근감사·자율 감사위 설치사 — 법 §542의10)",
+      "paragraphs": [4, 7],
       "sanction_scope": null,
       "table_content": "감사위원 합산 3% 룰 (사내·사외 무관)",
       "table_applies_to": "자산 2조+ 또는 1천억-2조 감사위 설치사",
@@ -162,6 +167,7 @@
         }
       ],
       "threshold_decree": "상법 시행령 §33(집중투표 특례 대상 — 자산 2조+)",
+      "paragraphs": null,
       "sanction_scope": null,
       "table_content": "자산 2조+ 집중투표 의무화 (정관 배제 불가)",
       "table_applies_to": "자산 2조+",
@@ -191,6 +197,7 @@
         }
       ],
       "threshold_decree": "상법 시행령 §37①(감사위 의무설치 — 자산 2조+)",
+      "paragraphs": [2],
       "sanction_scope": null,
       "table_content": "감사위원 분리선출 2명 이상 (기존 1명)",
       "table_applies_to": "자산 2조+",
@@ -220,6 +227,7 @@
         }
       ],
       "threshold_decree": null,
+      "paragraphs": null,
       "sanction_scope": "상장사 (과태료 제635조③제9호)",
       "table_content": "자사주 의무소각 (취득 후 1년 내) — 공포 즉시 시행",
       "table_applies_to": "모든 회사 (비상장 포함 · 과태료는 상장사만)",
@@ -249,6 +257,7 @@
         }
       ],
       "threshold_decree": null,
+      "paragraphs": null,
       "sanction_scope": null,
       "table_content": "자사주 합병·분할 시 신주 배정 금지",
       "table_applies_to": "모든 회사",
@@ -278,6 +287,7 @@
         }
       ],
       "threshold_decree": "상법 시행령(§542의14 규모 — 별도 대통령령으로 정함)",
+      "paragraphs": null,
       "sanction_scope": null,
       "table_content": "전자주주총회 의무 개최",
       "table_applies_to": "일정 규모+",

--- a/open_proxy_mcp/services/law_lookup.py
+++ b/open_proxy_mcp/services/law_lookup.py
@@ -44,7 +44,6 @@ from open_proxy_mcp.services.proxy_advise import (
     _agenda_pattern_match,
     _load_law_layer_rules,
     _load_law_provisions,
-    _law_provision_detail,
 )
 
 logger = logging.getLogger(__name__)
@@ -804,6 +803,125 @@ def _reverse_bridge(rec: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
     return groups
 
 
+# ── 조문별 시행 게이트 — SSOT(law_provisions.json) ↔ 후보 조문, **항 단위** ──────────
+# 260903 실측: as_of=2026-09-03 에 §542의12·§542의7 을 조문번호로 조회하면 '현행'만 찍히고
+# §542의12②(분리선출 2명, 2026-09-10 시행)·§542의7③(정관 배제 금지, 2026-09-10 시행)에 아무
+# 표지가 없었다. 종전 flag 경로는 **bridge 룰의 첫 번째 룰**의 provision 만 봤다 — 조문번호 직접
+# 조회는 bridge 가 아예 없어 진입조차 안 했고, bridge 가 있어도 두 번째 룰(다른 조항)은 버렸다.
+# 게다가 룰의 law_reference 가 §382의2 를 가리키면 §382의2 에 §542의7③ 의 날짜가 붙었다(오귀속).
+# 이제 SSOT 조항을 **조문번호로 직접** 후보에 맞추고, article 의 '제N항'·`paragraphs` 로 항까지
+# 좁힌다. corpus 스냅샷은 개정 조문을 이미 담고 있으므로(상법 법률 2026-03-06 시행본) 전문이
+# '현행'이어도 그 안의 어떤 항은 as_of 시점 미시행일 수 있다 — 그걸 항 옆에 표지로 붙인다.
+_INT_TO_CIRCLED: dict[int, str] = {v: k for k, v in CIRCLED_TO_INT.items()}
+_PROVISIONS_BY_ARTICLE_CACHE: dict[str, list[tuple[dict[str, Any], list[int]]]] | None = None
+
+
+def _provision_paragraphs(prov: dict[str, Any]) -> dict[str, list[int]]:
+    """SSOT 조항 → {article_no: [항 번호...]}. article 문자열의 '제N항' + 선택 `paragraphs` 합집합.
+    항이 하나도 없으면 [] = 조문 전체."""
+    out: dict[str, list[int]] = {}
+    for ref in extract_article_refs(prov.get("article", "") or ""):
+        paras = out.setdefault(ref["article_no"], [])
+        if ref.get("hang") and ref["hang"] not in paras:
+            paras.append(ref["hang"])
+    explicit = [int(x) for x in (prov.get("paragraphs") or [])]
+    if explicit:
+        for art in out:
+            out[art] = sorted(set(out[art]) | set(explicit))
+    return out
+
+
+def _provisions_by_article() -> dict[str, list[tuple[dict[str, Any], list[int]]]]:
+    """{상법 article_no: [(provision, paragraphs)]} — SSOT 는 상법 개정 대장이라 법은 상법 하나."""
+    global _PROVISIONS_BY_ARTICLE_CACHE
+    if _PROVISIONS_BY_ARTICLE_CACHE is not None:
+        return _PROVISIONS_BY_ARTICLE_CACHE
+    table: dict[str, list[tuple[dict[str, Any], list[int]]]] = {}
+    for prov in _load_law_provisions().values():
+        for art, paras in _provision_paragraphs(prov).items():
+            table.setdefault(art, []).append((prov, paras))
+    _PROVISIONS_BY_ARTICLE_CACHE = table
+    return table
+
+
+def _paragraph_label(paras: list[int]) -> str:
+    return ("".join(_INT_TO_CIRCLED.get(n, f"({n})") for n in paras) + "항") if paras else "조문 전체"
+
+
+def provision_gates(rec: dict[str, Any], as_of_iso: str) -> list[dict[str, Any]]:
+    """이 조문에 걸린 SSOT 조항들의 as_of 기준 상태(항 단위).
+
+    state: pending(시행일 前) · grace(시행됐으나 유예 종료 前 — 미이행이 아직 위반 아님) · in_force.
+    label 은 md 에 그대로 붙는 표지: 「시행예정 YYYY-MM-DD」·「유예 종료 YYYY-MM-DD」. 상법 **법률**
+    조문에만 — 시행령은 SSOT 밖(threshold_decree 는 임계 출처일 뿐 개정 대장이 아니다).
+    """
+    if rec.get("law_short") != "상법" or (rec.get("law_tier") or 0) != 0:
+        return []
+    gates: list[dict[str, Any]] = []
+    for prov, paras in _provisions_by_article().get(rec.get("article_no") or "", []):
+        eff = prov.get("effective_date") or ""
+        obl = prov.get("obligation_date") or ""
+        if eff and eff > as_of_iso:
+            state, label = "pending", f"시행예정 {eff}"
+        elif obl and obl > as_of_iso:
+            state, label = "grace", f"유예 종료 {obl}"
+        else:
+            state, label = "in_force", ""
+        gates.append({
+            "provision_id": prov.get("provision_id"),
+            "paragraphs": list(paras),
+            "paragraph_label": _paragraph_label(paras),
+            "effective_date": eff or None,
+            "obligation_date": obl or None,
+            "first_agm_trigger": bool(prov.get("first_agm_trigger")),
+            "amendment": f"{prov.get('amendment_round_label') or ''} 개정 {prov.get('law_no') or ''}".strip(),
+            "content": prov.get("table_content"),
+            "applies_to": prov.get("table_applies_to"),
+            "state": state,
+            "label": label,
+        })
+    return gates
+
+
+def _apply_provision_gates(item: dict[str, Any], gates: list[dict[str, Any]]) -> None:
+    """게이트를 공개 item 에 새긴다 — flags(사람용 한 줄) · hang[*].gates(항 옆 표지) ·
+    gate_status(조문 요약: pending/partial_pending/grace/None) · gate_summary(표 '시행' 열용)."""
+    if not gates:
+        return
+    item["provision_gates"] = gates
+    active = [g for g in gates if g["state"] != "in_force"]
+    if not active:
+        return
+    # 항 옆 표지 — rec 의 hang 리스트는 인덱스 캐시와 공유되므로 **복사한 뒤** 새긴다.
+    hang = [dict(h) for h in (item.get("hang") or [])]
+    for g in active:
+        for h in hang:
+            if g["paragraphs"] and h.get("no") in g["paragraphs"]:
+                h.setdefault("gates", []).append(g["label"])
+    item["hang"] = hang
+    summaries: list[str] = []
+    for g in active:
+        head = f"{g['paragraph_label']} {g['label']}"
+        summaries.append(head)
+        note = f"{head} — {g['content'] or g['provision_id']} ({g['amendment']}"
+        if g.get("applies_to"):
+            note += f" · 적용 {g['applies_to']}"
+        note += ")"
+        if g["state"] == "pending" and g["first_agm_trigger"]:
+            note += " · 시행 후 최초 이사선임 주총부터 적용(주총일 기준)"
+        if g["state"] == "grace":
+            note += " · 시행됐으나 유예 종료 전 미이행은 위반 아님"
+        item.setdefault("flags", []).append(note)
+    whole_pending = any(g["state"] == "pending" and not g["paragraphs"] for g in active)
+    if whole_pending:
+        item["gate_status"] = "pending"
+    elif any(g["state"] == "pending" for g in active):
+        item["gate_status"] = "partial_pending"
+    else:
+        item["gate_status"] = "grace"
+    item["gate_summary"] = " · ".join(summaries)
+
+
 # ── payload ─────────────────────────────────────────────────────────────
 def _record_public(rec: dict[str, Any], *, include_full_text: bool, as_of_iso: str) -> dict[str, Any]:
     """후보 record → 공개 dict (조문 상세)."""
@@ -1200,16 +1318,13 @@ def build_law_lookup_payload(
             item["hang"], item["ho"] = [], {}   # 표만 남긴다 — 약한 후보의 본문은 노이즈다
         item["score"] = c["score"]
         item["signals"] = sorted(c["signals"])
-        # ① 진짜 조문별 미래시행은 SSOT(조항 대장)의 effective_date로만 단정.
-        det = _law_provision_detail((c.get("bridge") or {}).get("rules", [None])[0]) if c.get("bridge") else None
-        eff = (det or {}).get("effective_date") or ""
-        if eff and eff > as_of_iso:
-            note = f"미시행(시행 {eff})"
-            if det.get("first_agm_trigger"):
-                note += " · 시행 후 최초 이사선임 주총부터 적용(주총일 기준)"
-            item.setdefault("flags", []).append(note)
+        # ① 진짜 조문별 미래시행·유예는 SSOT(조항 대장)를 **조문번호로 직접** 맞춰 항 단위로 표시.
+        #    bridge 유무·룰 순서와 무관하다(260903 — 종전엔 bridge 첫 룰만 봐서 조문번호 조회에
+        #    표지가 전혀 안 붙었다). 표에만 남기는 약한 후보(hang 비움)에도 flags 는 남긴다.
+        _apply_provision_gates(item, provision_gates(rec, as_of_iso))
         # ② 전문(스냅샷) 자체가 시행예정본이면 조문별 현행여부 불명 — 확인필요 + 법령당 1회 경고.
-        elif item["in_force"] is None:
+        #    ①과 독립이다: 스냅샷이 미래본이어도 SSOT 가 아는 항의 시행 상태는 그대로 말한다.
+        if item["in_force"] is None:
             item.setdefault("flags", []).append("현행 여부 확인필요(전문 시행예정본)")
             lw = rec.get("law_short") or ""
             if lw not in version_warned:

--- a/open_proxy_mcp/tools/law_lookup.py
+++ b/open_proxy_mcp/tools/law_lookup.py
@@ -19,6 +19,22 @@ def _decisions_lines(items: list[dict[str, Any]]) -> list[str]:
     return lines
 
 
+def _force_label(r: dict[str, Any]) -> str:
+    """표 '시행' 열. 조문 전체가 아직 시행 전이면 「시행예정 YYYY-MM-DD」, 일부 항만 시행 전·유예 중이면
+    「현행 (②항 시행예정 YYYY-MM-DD)」 — 260903 이전엔 개정 항이 미시행이어도 '현행'만 찍혔다."""
+    if r.get("deleted"):
+        return "삭제"
+    _if = r.get("in_force")
+    base = "현행" if _if is True else ("확인필요" if _if is None else "미시행")
+    summary = r.get("gate_summary") or ""
+    if not summary:
+        return base
+    if r.get("gate_status") == "pending":
+        # 조문 전체가 시행 전 — 항 라벨(「조문 전체」)을 떼고 날짜만.
+        return summary.replace("조문 전체 ", "", 1)
+    return f"{base} ({summary})"
+
+
 def _render(payload: dict[str, Any]) -> str:
     d = payload["data"]
     status = payload.get("status")
@@ -54,8 +70,7 @@ def _render(payload: dict[str, Any]) -> str:
     lines.append("| # | 법령 | 조문 | 제목 | 시행 | score | 근거 |")
     lines.append("|---|---|---|---|---|---|---|")
     for i, r in enumerate(results, 1):
-        _if = r.get("in_force")
-        force = "삭제" if r.get("deleted") else ("현행" if _if is True else ("확인필요" if _if is None else "미시행"))
+        force = _force_label(r)
         sig = "·".join(r.get("signals", []))
         lines.append(
             f"| {i} | {r.get('law')} | `{r.get('article_no')}` | {r.get('article_title') or '-'} | "
@@ -76,7 +91,8 @@ def _render(payload: dict[str, Any]) -> str:
         # 항/호
         for h in r.get("hang", [])[:12]:
             mark = " (삭제)" if h.get("deleted") else ""
-            lines.append(f"  - **{h.get('no')}항**{mark} {h.get('text', '')[:160]}")
+            gate = f" ⏳ {' · '.join(h['gates'])}" if h.get("gates") else ""
+            lines.append(f"  - **{h.get('no')}항**{mark}{gate} {h.get('text', '')[:160]}")
             for ho in (r.get("ho") or {}).get(str(h.get("no")), [])[:12]:
                 lines.append(f"    - {ho.get('no')}. {ho.get('text', '')[:120]}")
         if r.get("full_text"):
@@ -143,8 +159,10 @@ def register_tools(mcp):
         + B(40룰 bridge 재사용, `_agenda_pattern_match` — 정관패턴↔조문, free-text law_reference도 파싱)
         + C(corpus 키워드, idf·anchor 게이트 — 두루뭉술 질의는 requires_review). 보수적: 폐쇄 큐레이션 어휘
         (`law_lookup_synonyms.json`)만, false-friend guard(이사↮사외이사 등), difflib 없음. 삭제 조문 보존+경고.
-        미시행: 전문 시행예정본은 조문별 현행여부 '확인필요'로 유보(단정 X), 진짜 조문별 미래시행만 SSOT
-        effective_date로 flag. 조문번호 법령 미지정+중복 → ambiguous. 강매치 아니면 폴백 유형별 안내(fallback).
+        미시행: 전문 시행예정본은 조문별 현행여부 '확인필요'로 유보(단정 X). 진짜 조문별 미래시행·유예는 SSOT
+        (law_provisions.json)를 조문번호로 직접 맞춰 **항 단위**로 「시행예정 YYYY-MM-DD」·「유예 종료 YYYY-MM-DD」
+        표지를 붙인다(표 '시행' 열·flags·항 옆 ⏳, data.results[*].provision_gates) — 원문이 개정 조문을 이미
+        담고 있어도 as_of 시점에 아직 효력 없는 항을 '현행'으로 읽지 않게. 조문번호 법령 미지정+중복 → ambiguous. 강매치 아니면 폴백 유형별 안내(fallback).
         **범위 밖은 조문을 붙이지 않는다** — 거래소 상장규정·공시규정·업무규정(관리종목·상장폐지·실질심사·
         불성실공시·정리매매 등)과 아직 안 읽은 법률(법인세법·소득세법·신탁법·여신전문금융업법 등)은 원문에 없으므로 어휘가 겹쳐도 조문을 반환하지 않고 범위 안내로 끝낸다
         (fallback.type=out_of_corpus_topic · data.results_suppressed). 용어 자체를 못 알아본 질의(too_vague·

--- a/tests/test_law_lookup_effective_gates.py
+++ b/tests/test_law_lookup_effective_gates.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+"""law_lookup — 조문별 시행 게이트(항 단위, SSOT `law_provisions.json`). network 0콜.
+
+260903 실측(as_of=2026-09-03): §542의12·§542의7 을 조문번호로 조회하면 표 '시행' 열이 「현행」이고
+§542의12②(분리선출 2명, 2026-09-10 시행)·§542의7③(정관 배제 금지, 2026-09-10 시행)에 아무 표지도
+없었다. 원인 — flag 경로가 **bridge 첫 룰**의 provision 만 봤다. 조문번호 직접 조회는 bridge 가 없어
+진입조차 못 했고, 있어도 두 번째 룰(다른 조항)은 버렸다. corpus 스냅샷은 개정 조문을 이미 담고 있어
+(상법 법률 2026-03-06 시행본) 전문이 '현행'이어도 그 안의 어떤 항은 as_of 시점 아직 효력이 없다.
+
+여기서 잠그는 것: ① SSOT 조항을 조문번호로 직접 맞춰 항 단위 표지가 붙는다 ② as_of 가 시행일을 넘으면
+표지가 사라진다 ③ md 표·항 줄에 「시행예정 YYYY-MM-DD」·「유예 종료 YYYY-MM-DD」가 보인다
+④ SSOT `paragraphs` 가 가리키는 항이 원문에 실재한다.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from open_proxy_mcp.services.law_lookup import (
+    _apply_provision_gates,
+    _provision_paragraphs,
+    build_law_lookup_payload,
+    load_index,
+    provision_gates,
+)
+from open_proxy_mcp.tools.law_lookup import _render
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SSOT = ROOT / "open_proxy_mcp" / "data" / "laws" / "law_provisions.json"
+
+
+def _top(q: str, as_of: str) -> dict:
+    p = build_law_lookup_payload(q, law="상법", as_of=as_of, top_k=3, include_full_text=False)
+    r = p["data"]["results"][0]
+    assert r["law"] == "상법" and r["article_no"] == q, (q, r["article_no"])
+    return r
+
+
+def _md_row(q: str, as_of: str) -> tuple[str, str]:
+    """(표 1행, 상세 블록) — 사용자가 보는 md 그대로."""
+    p = build_law_lookup_payload(q, law="상법", as_of=as_of, top_k=3, include_full_text=False)
+    md = _render(p)
+    row = next(l for l in md.splitlines() if l.startswith("| 1 |"))
+    return row, md
+
+
+# ── 1. 세 조문 × as_of 전/후 — 사용자 지정 회귀 케이스 ─────────────────────────
+@pytest.mark.parametrize("article,as_of,para,label", [
+    ("제542조의12", "2026-09-03", 2, "시행예정 2026-09-10"),   # 분리선출 감사위원 2명 (2차)
+    ("제542조의7", "2026-09-03", 3, "시행예정 2026-09-10"),    # 정관으로 집중투표 배제 금지 (2차)
+    ("제382조의3", "2025-07-01", None, "시행예정 2025-07-22"),  # 이사 충실의무 (1차, 조문 전체)
+])
+def test_pending_paragraph_is_flagged_before_effective_date(article, as_of, para, label):
+    r = _top(article, as_of)
+    assert r["in_force"] is True or r["in_force"] is None, "SSOT 게이트가 in_force 를 단정하면 안 된다"
+    assert any(label in f for f in r.get("flags", [])), r.get("flags")
+    assert label in (r.get("gate_summary") or "")
+    gates = [g for g in r["provision_gates"] if g["state"] == "pending"]
+    assert gates and all(g["label"] == label for g in gates), gates
+    if para is None:
+        assert r["gate_status"] == "pending"
+        assert all(g["paragraphs"] == [] for g in gates)
+    else:
+        assert r["gate_status"] == "partial_pending"
+        assert [g["paragraphs"] for g in gates] == [[para]]
+        # 항 옆 표지 — 그 항에만 붙고 다른 항에는 안 붙는다.
+        flagged = {h["no"] for h in r["hang"] if h.get("gates")}
+        assert flagged == {para}, flagged
+
+
+@pytest.mark.parametrize("article,as_of", [
+    ("제542조의12", "2026-09-10"),   # 시행일 당일부터 현행
+    ("제542조의7", "2026-09-10"),
+    ("제382조의3", "2026-09-03"),
+])
+def test_no_pending_flag_on_or_after_effective_date(article, as_of):
+    r = _top(article, as_of)
+    assert not any("시행예정" in f for f in r.get("flags", [])), r.get("flags")
+    assert r.get("gate_status") is None and not r.get("gate_summary")
+    assert not any(h.get("gates") for h in r["hang"])
+    # SSOT 조항 자체는 여전히 붙어 있다(in_force 상태로) — 「근거는 남기되 표지는 뗀다」.
+    assert r["provision_gates"] and all(g["state"] == "in_force" for g in r["provision_gates"])
+
+
+def test_first_agm_trigger_note_rides_on_pending_flag():
+    r = _top("제542조의7", "2026-09-03")
+    f = next(f for f in r["flags"] if "③항 시행예정" in f)
+    assert "최초 이사선임 주총" in f
+
+
+def test_other_paragraphs_of_the_same_article_are_not_flagged():
+    """§542의12④·⑦(합산 3%, 2026-07-23 시행)은 as_of=2026-09-03 에 이미 현행 — ②만 표지."""
+    r = _top("제542조의12", "2026-09-03")
+    pending = [g for g in r["provision_gates"] if g["state"] == "pending"]
+    in_force = [g for g in r["provision_gates"] if g["state"] == "in_force"]
+    assert [g["provision_id"] for g in pending] == ["§542의12_감사위원_분리선출_2차"]
+    assert any(g["provision_id"] == "§542의12_감사위원_합산3%_1차" and g["paragraphs"] == [4, 7]
+               for g in in_force)
+    # 2026-07-01 이면 둘 다 미시행 — 각각 제 날짜로.
+    r2 = _top("제542조의12", "2026-07-01")
+    labels = {g["provision_id"]: g["label"] for g in r2["provision_gates"]}
+    assert labels["§542의12_감사위원_합산3%_1차"] == "시행예정 2026-07-23"
+    assert labels["§542의12_감사위원_분리선출_2차"] == "시행예정 2026-09-10"
+    assert {h["no"] for h in r2["hang"] if h.get("gates")} == {2, 4, 7}
+
+
+def test_grace_period_is_labelled_with_obligation_date():
+    """§542의8①(독립이사 1/3): 2026-07-23 시행, 요건 구비는 2027-07-23 까지 — 그 사이는 「유예 종료」."""
+    r = _top("제542조의8", "2026-09-03")
+    assert r["gate_status"] == "grace"
+    assert "①항 유예 종료 2027-07-23" in r["gate_summary"]
+    assert any("유예 종료 2027-07-23" in f and "위반 아님" in f for f in r["flags"])
+    assert {h["no"] for h in r["hang"] if h.get("gates")} == {1}
+    r_after = _top("제542조의8", "2027-07-23")
+    assert r_after.get("gate_status") is None
+
+
+# ── 2. md 출력 — 표 '시행' 열 + 항 옆 ⏳ 표지 ────────────────────────────────
+def test_md_shows_pending_badge_on_table_and_paragraph():
+    row, md = _md_row("제542조의12", "2026-09-03")
+    assert "현행 (②항 시행예정 2026-09-10)" in row, row
+    assert "- **2항** ⏳ 시행예정 2026-09-10" in md
+    assert "- **4항** ⏳" not in md
+    row7, md7 = _md_row("제542조의7", "2026-09-03")
+    assert "현행 (③항 시행예정 2026-09-10)" in row7, row7
+    assert "- **3항** ⏳ 시행예정 2026-09-10" in md7
+    assert "최초 이사선임 주총" in md7
+
+
+def test_md_whole_article_pending_replaces_current_label():
+    row, _ = _md_row("제382조의3", "2025-07-01")
+    assert "| 시행예정 2025-07-22 |" in row, row
+    row_after, md_after = _md_row("제382조의3", "2026-09-03")
+    assert "| 현행 |" in row_after and "시행예정" not in md_after
+
+
+def test_md_grace_badge():
+    row, md = _md_row("제542조의8", "2026-09-03")
+    assert "현행 (①항 유예 종료 2027-07-23)" in row, row
+    assert "- **1항** ⏳ 유예 종료 2027-07-23" in md
+
+
+# ── 3. 게이트가 새지 않는다 — 시행령·타법·캐시 공유 ───────────────────────────
+def test_gates_never_touch_decree_or_other_laws():
+    idx = load_index()
+    for rec in idx["articles"]:
+        if rec.get("law_short") != "상법" or (rec.get("law_tier") or 0) != 0:
+            assert provision_gates(rec, "2020-01-01") == [], rec["id"]
+
+
+def test_gate_annotation_does_not_mutate_shared_index_record():
+    """hang 은 인덱스 캐시와 공유되는 리스트 — 복사하지 않고 새기면 다음 질의(다른 as_of)에 표지가 남는다."""
+    rec = next(a for a in load_index()["articles"] if a["id"] == "상법:제542조의12")
+    before = json.dumps(rec["hang"], ensure_ascii=False)
+    item = {"hang": rec["hang"], "ho": rec.get("ho") or {}}
+    _apply_provision_gates(item, provision_gates(rec, "2026-09-03"))
+    assert any(h.get("gates") for h in item["hang"])
+    assert json.dumps(rec["hang"], ensure_ascii=False) == before, "인덱스 레코드가 오염됐다"
+
+
+def test_deleted_paragraph_keeps_its_own_mark():
+    """§542의7④ 는 2차 개정으로 삭제 — 삭제 표지는 그대로, 게이트 표지가 덮어쓰지 않는다."""
+    r = _top("제542조의7", "2026-09-03")
+    h4 = next(h for h in r["hang"] if h["no"] == 4)
+    assert h4["deleted"] and not h4.get("gates")
+
+
+# ── 4. SSOT `paragraphs` 정합 — 가리키는 항이 원문에 실재한다 ────────────────
+def test_ssot_paragraphs_exist_in_corpus():
+    data = json.loads(SSOT.read_text(encoding="utf-8"))
+    assert "paragraphs" in data["schema"]
+    by_id = {a["id"]: a for a in load_index()["articles"]}
+    seen = 0
+    for prov in data["provisions"]:
+        for art, paras in _provision_paragraphs(prov).items():
+            rec = by_id.get(f"상법:{art}")
+            assert rec, f"{prov['provision_id']}: {art} 가 corpus 에 없다"
+            have = {h["no"] for h in rec.get("hang") or []}
+            for n in paras:
+                assert n in have, f"{prov['provision_id']}: {art} 제{n}항이 원문에 없다({sorted(have)})"
+                seen += 1
+    assert seen >= 5, "항 단위 조항이 너무 적다 — paragraphs 가 사라졌나"

--- a/wiki/rules/laws/README.md
+++ b/wiki/rules/laws/README.md
@@ -1,7 +1,7 @@
 ---
 type: readme
 title: rules/laws/ — 한국 자본시장 법령 자료
-updated: 2026-09-02
+updated: 2026-09-03
 ---
 
 # wiki/rules/laws/ — 한국 자본시장 법령 자료
@@ -29,7 +29,7 @@ updated: 2026-09-02
 
 | 파일 | 종류 | 용도 |
 |---|---|---|
-| **`law_provisions.json`** (패키지) | 원본(SSOT) | 조항 대장(9개). 조문번호·**시행일·공포일**·유예도래일(obligation_date)·적용대상 티어(scope)·최초주총 적용(first_agm_trigger)의 유일 출처. md 표 자동생성 + 엔진 날짜 검증의 기준 |
+| **`law_provisions.json`** (패키지) | 원본(SSOT) | 조항 대장(9개). 조문번호·**시행일·공포일**·유예도래일(obligation_date)·적용대상 티어(scope)·최초주총 적용(first_agm_trigger)·**개정 항 번호(paragraphs, 260903)**의 유일 출처. md 표 자동생성 + 엔진 날짜 검증 + `law_lookup` 항 단위 시행 표지의 기준 |
 | **`상법-2025-2026-종합.md`** | 사람 가독 | 1·2·3차 상법 개정 + 정관 우회 시나리오 + catalog. **유일 master**. '시행 타임라인' 표는 원본에서 자동생성(AUTOGEN 마커 — 직접 수정 금지) |
 | **`law_layer_rules.json`** (패키지) | 머신리더블 | proxy_advise._law_layer 직접 로드. 실제 개수는 `/health` 의 `data.law_rules` 로 본다 — 여기 숫자를 적으면 손으로 맞춰야 하고, 260814 에 docstring 이 「36 룰」인 채 실물은 40룰로 갈라져 있었다. 각 룰의 `provision` 필드가 원본 조항을 가리킴 |
 
@@ -47,6 +47,18 @@ updated: 2026-09-02
 3. 엔진 발화 시점(`law_layer_rules.json`의 `applies_after`)을 바꿔야 하면 거기서 수정
 4. `python3 scripts/wiki_lint.py --strict` → 검사[7]이 원본↔md표↔엔진 3자 정합 확인
    (날짜를 한 곳만 고쳐 나머지가 어긋나면 CI 실패)
+
+### 조항이 손댄 항(paragraph) — `paragraphs` 필드 (260903)
+`law_lookup`은 SSOT 조항을 **조문번호로 직접** 후보 조문에 맞추고, `article`의 '제N항' 또는 `paragraphs`
+배열로 항을 좁혀 `as_of` 기준 「시행예정 YYYY-MM-DD」·「유예 종료 YYYY-MM-DD」 표지를 **그 항 옆에** 붙인다.
+corpus 스냅샷이 개정 본문을 이미 담고 있어서(상법 법률 2026-03-06 시행본) 전문이 '현행'이어도 항은 미시행일
+수 있기 때문이다. 규칙:
+- `article`에 '제N항'이 있으면 그 항(§542의7③·§542의8①·§341의4①). 둘 다 없으면 **조문 전체**(§382의3·§542의14).
+- 한 조문에 여러 개정이 걸리면(§542의12: 1차 합산3% = ④⑦, 2차 분리선출 = ②) `paragraphs`로 나눈다.
+  원문 `<개정 YYYY.M.D>` 마커로 대조해 적는다 — `tests/test_law_lookup_effective_gates.py`가 가리킨 항이
+  원문에 실재하는지 확인한다.
+- 시행령 조문은 SSOT 밖(`threshold_decree`는 임계 출처일 뿐) — 표지가 붙지 않는다.
+- 새 조항을 넣을 때 항을 모르면 `null`로 두면 조문 전체로 표시된다. 틀린 항보다 넓은 표지가 낫다.
 
 ### 룰 패턴/판단 변경 시 (날짜 외)
 → `law_layer_rules.json` JSON 수정 (코드 변경 X)

--- a/wiki/tools/law_lookup.md
+++ b/wiki/tools/law_lookup.md
@@ -7,7 +7,7 @@ data_source: [legalize-kr 원문(상법·자본시장법·공정거래법·외�
 related_disclosures: [주주총회소집공고]
 related_concepts: [정관변경, 집중투표, 감사위원-의결권-제한, 5%-대량보유]
 created: 2026-07-13
-updated: 2026-09-02
+updated: 2026-09-03
 ---
 
 # law_lookup — 정관↔법령 양방향 조회
@@ -59,7 +59,7 @@ updated: 2026-09-02
 - `direction`: `auto`(기본) · `clause_to_law`(정관/키워드→법) · `law_to_clause`(법조문/키워드→정관·안건)
 - `law`: 필터 `""`(전체) · 상법 · 자본시장법 · 공정거래법 · 외부감사법 · 지배구조법 · 상증세법 · 금융지주회사법 · 금산법 · 은행법 · 보험업법 (시행령 포함)
 - `top_k`: 표시 후보 수(기본 10). 전문은 **강매칭(score ≥ 0.60) 전부 + 최소 3건**까지만 붙고 그 아래 꼬리는 표로만 남는다(`data.full_text_limited_to`) — exact 여도 「시정조치」처럼 글자만 겹친 다른 법 조문 전문이 딸려 나오지 않게(260902).
-- `as_of`: 기준일(기본 오늘) — 시행/미시행·명칭변경(사외이사↔독립이사) 게이팅
+- `as_of`: 기준일(기본 오늘) — 시행/미시행·유예(항 단위 게이트)·명칭변경(사외이사↔독립이사) 게이팅
 - `include_full_text`: 조문 원문 전문 포함(기본 True)
 
 ## 매칭 (3신호 융합 — 보수적)
@@ -83,8 +83,28 @@ difflib 없음. 삭제 조문 보존+경고, 조문번호 법령 중복 → `amb
 **미시행 유보 (260713 수정)**: corpus의 `enforcement`는 법 **전문(공포본)** 시행일자라 개별 조문의
 현행 여부로 쓰면 안 된다 — 미래 시행 개정본을 vendored하면 그 법 **모든 조문**이 거짓 '미시행'으로
 찍힌다(자본시장법 법률 599/599 오탐). 그래서 ① 전문 시행일이 미래면 조문 `in_force`를 **단정(False)하지
-않고** `None`(현행 여부 확인필요)로 두고 법령당 1회 버전 경고. ② 진짜 **조문별** 미래시행은
-SSOT(`law_provisions.json`)의 `effective_date`로만 `미시행(시행 YYYY-MM-DD)` flag(+first_agm_trigger).
+않고** `None`(현행 여부 확인필요)로 두고 법령당 1회 버전 경고. ② 진짜 **조문별** 미래시행·유예는
+SSOT(`law_provisions.json`)로만 말한다 — 아래 항 단위 게이트.
+
+**항 단위 시행 게이트 (260903)**: corpus 스냅샷은 **개정 조문을 이미 담고 있다**(상법 법률 2026-03-06
+시행본에 2차 개정 §542의12②·§542의7③ 본문이 들어 있다). 그래서 전문이 '현행'이어도 그 안의 어떤 항은
+`as_of` 시점 아직 효력이 없다. 260903 실측(as_of=2026-09-03): §542의12·§542의7 을 조문번호로 조회하면
+'시행' 열이 「현행」뿐이고 ②·③에 표지가 없었다 — 종전 flag 경로가 **bridge 첫 룰**의 provision 만
+봐서, 조문번호 직접 조회(bridge 없음)는 진입조차 못 했고 룰의 `law_reference`가 §382의2 를 가리키면
+그 조문에 §542의7③ 날짜가 붙었다(오귀속). 이제 `provision_gates()`가 SSOT 조항을 **조문번호로 직접**
+후보에 맞추고 `article`의 '제N항' + `paragraphs`(SSOT 신설 필드, 원문 `<개정 YYYY.M.D>` 마커로 대조)로
+항까지 좁힌다. 상법 **법률**만(시행령은 SSOT 밖).
+
+| as_of 위치 | state | 표지 | 표 '시행' 열 |
+|---|---|---|---|
+| 시행일 前 | `pending` | 「②항 시행예정 YYYY-MM-DD」(+first_agm_trigger 면 최초 이사선임 주총 주석) | 항 단위면 `현행 (②항 시행예정 …)`, 조문 전체면 `시행예정 …` |
+| 시행 後 · 유예 종료(`obligation_date`) 前 | `grace` | 「①항 유예 종료 YYYY-MM-DD · 미이행은 위반 아님」 | `현행 (①항 유예 종료 …)` |
+| 유예 종료 後 | `in_force` | 없음 (`provision_gates`에 근거만 남는다) | `현행` |
+
+출력 자리: `flags`(사람용 한 줄) · `hang[*].gates`(항 옆 ⏳) · `gate_status`/`gate_summary`(표) ·
+`provision_gates`(기계용 — provision_id·paragraphs·effective/obligation_date·state). `in_force`는 건드리지
+않는다(전문 단위 3-상태 그대로). 회귀: `tests/test_law_lookup_effective_gates.py`(§542의12②·§542의7③·
+§382의3 as_of 전/후 + md 표지 + 캐시 비오염 + SSOT paragraphs↔원문 실재).
 
 ## 추천 질문 (자연어 예시)
 | 방향 | 이럴 때 |


### PR DESCRIPTION
## 요약

SSOT(`law_provisions.json`)의 조항을 **조문번호로 직접** 후보 조문에 맞추고, `article`의 '제N항' 또는 신설 `paragraphs` 필드로 항을 좁혀 `as_of` 기준 「시행예정 YYYY-MM-DD」·「유예 종료 YYYY-MM-DD」 표지를 **항 단위**로 붙인다. 

260903 실측: §542의12·§542의7을 조문번호로 조회하면 '현행'만 찍히고 ②·③에 표지가 없었다 — 종전 flag 경로가 bridge 첫 룰의 provision만 봐서, 조문번호 직접 조회(bridge 없음)는 진입조차 못 했고 룰의 `law_reference`가 다른 조문을 가리키면 그 조문에 날짜가 붙었다(오귀속). corpus 스냅샷이 개정 본문을 이미 담고 있어서(상법 법률 2026-03-06 시행본) 전문이 '현행'이어도 항은 미시행일 수 있기 때문이다.

## 주요 변경

### 1. 항 단위 게이트 로직 (`open_proxy_mcp/services/law_lookup.py`)
- `_provision_paragraphs()`: SSOT 조항 → `{article_no: [항 번호...]}` 변환. `article` 문자열의 '제N항' + 선택 `paragraphs` 합집합
- `_provisions_by_article()`: 캐시된 `{상법 article_no: [(provision, paragraphs)]}` 테이블 구축
- `provision_gates()`: 조문별 SSOT 조항들의 as_of 기준 상태(pending/grace/in_force) 반환. 상법 **법률**만(시행령은 SSOT 밖)
- `_apply_provision_gates()`: 게이트를 공개 item에 새김 — `flags`(사람용) · `hang[*].gates`(항 옆 ⏳) · `gate_status`/`gate_summary`(표) · `provision_gates`(기계용). **hang 리스트는 인덱스 캐시와 공유되므로 복사 후 새긴다**(캐시 비오염)
- `build_law_lookup_payload()`: bridge 유무·룰 순서와 무관하게 `provision_gates()`로 조문번호 직접 맞춤. 표에만 남기는 약한 후보(hang 비움)에도 flags 유지

### 2. 렌더링 (`open_proxy_mcp/tools/law_lookup.py`)
- `_force_label()`: 표 '시행' 열 생성. 조문 전체 pending이면 「시행예정 YYYY-MM-DD」, 일부 항만 pending/grace면 「현행 (②항 시행예정 …)」
- `_render()`: 항 옆에 ⏳ 표지 + 게이트 라벨 붙임

### 3. SSOT 스키마 (`open_proxy_mcp/data/laws/law_provisions.json`)
- `paragraphs` 필

https://claude.ai/code/session_01EXPC8Luvo6JQ4T45F86GXb