### PR TITLE
pay_agenda: Select latest annual notice, not most recent

### DIFF
--- a/open_proxy_mcp/services/director_board.py
+++ b/open_proxy_mcp/services/director_board.py
@@ -866,35 +866,92 @@ async def _pay_gap_scope(
 
 # ── pay_agenda: 주총 보수한도 안건(올해 제안) vs 작년 실적 ────────────────────
 
-async def _pay_agenda_scope(company_query: str, *, warnings: list[str]) -> dict[str, Any]:
+# pay_agenda 소집공고 lookback. 12개월(=360일)은 매년 같은 날짜에 나오는 정기 소집공고가 며칠씩
+# 구간 밖으로 밀려 「정기 없음」이 될 수 있어(주총 성수기 직전) 한 달 여유를 둔다. 보수한도 안건은
+# 연 1회 정기주총 안건이므로 구간 안에 정기 공고는 항상 1건 이상 있어야 정상.
+_PAY_AGENDA_LOOKBACK_MONTHS = 13
+
+
+async def _pay_agenda_scope(
+    company_query: str, corp_code: str = "", *, warnings: list[str]
+) -> dict[str, Any]:
     """주총 소집공고의 '이사 보수한도 승인' 안건을 재사용해 올해 제안 한도 vs 작년 한도·실지급 비교.
 
     소집공고 하나에 current(올해 제안)·prior(작년 한도+실지급)가 모두 들어있어(shareholder_meeting
     notice가 이미 파싱), 별도 계산 없이 '작년 소진율'과 '올해 인상률'을 뽑아 보수한도 안건 의결권
     판단 신호를 만든다. 가치판단(찬반)은 하지 않고 인상률·작년소진율 사실만.
+
+    회차 선택은 **최근 정기주총 소집공고**(meeting_type="annual")다 — 보수한도 승인은 정기주총 안건이라
+    `auto`(임박한 회차 우선)로 고르면 임시주총이 정기 뒤에 끼는 회사에서 안건이 없는 공고를 읽는다
+    (260904 실측 고려아연: 09-09 임시주총 공고가 최신이라 3월 정기 제6호 보수한도 120억을 놓치고
+    no_agenda). 검색은 list.json `pblntf_detail_ty=E006`(주주총회소집공고)으로 먼저 좁힌 뒤 본문의
+    정기/임시 표기로 분류한다(shareholder_meeting 공용 경로). 정기 공고가 구간에 없고 임시만 있으면
+    그 사실을 warnings에 적는다.
     """
-    from open_proxy_mcp.services.shareholder_meeting import build_shareholder_meeting_payload
+    from open_proxy_mcp.services.shareholder_meeting import (
+        build_shareholder_meeting_payload,
+        latest_notice_coverage,
+    )
 
     # 소집공고 파싱을 8초로 제한(perf 260709: 일부 회사가 DART viewer HTML crawl 폴백에 6~21초
     # 낭비하는데 warning상 "개선 안 됨"=무용. director_board는 실패 시 compensation 표 승인한도
     # YoY 폴백이 이미 있으므로 타임아웃하면 자동 대체된다 — 한솔케미칼 21.6초→8초).
     try:
         payload = await asyncio.wait_for(
-            build_shareholder_meeting_payload(company_query, scope="compensation"), timeout=8.0)
+            build_shareholder_meeting_payload(
+                company_query, scope="compensation", meeting_type="annual",
+                lookback_months=_PAY_AGENDA_LOOKBACK_MONTHS,
+            ),
+            timeout=8.0)
     except asyncio.TimeoutError:
         warnings.append("[pay_agenda] 소집공고 파싱 8초 초과 — 사업보고서 승인한도 YoY 폴백으로 대체.")
         return {"status": "no_agenda",
                 "note": "주총 소집공고 파싱 타임아웃(viewer crawl) — 사업보고서 한도 YoY 폴백 사용."}
+    pdata = payload.get("data") or {}
+
+    # 정기 소집공고 자체가 구간에 없는 갈래 — 임시주총만 있는지 확인해 이유를 남긴다.
+    if payload.get("status") == AnalysisStatus.NO_FILING.value and corp_code:
+        try:
+            coverage = await asyncio.wait_for(
+                latest_notice_coverage(corp_code, lookback_months=_PAY_AGENDA_LOOKBACK_MONTHS),
+                timeout=8.0)
+        except (asyncio.TimeoutError, DartClientError):
+            coverage = {}
+        extraordinary = coverage.get("latest_extraordinary") or None
+        window = pdata.get("requested_window") or {}
+        span = f"{window.get('start_date', '')}~{window.get('end_date', '')}".strip("~")
+        if extraordinary:
+            when = extraordinary.get("meeting_date") or extraordinary.get("notice_date") or ""
+            warnings.append(
+                f"[pay_agenda] 조회 구간({span}) 소집공고는 임시주총({when}, rcept "
+                f"{extraordinary.get('notice_rcept_no', '')})뿐 — 보수한도 승인은 정기주총 안건이라 "
+                "임시주총 공고엔 없음(종합 조회에서는 사업보고서 승인한도 전년비로 대신함).")
+            return {"status": "no_annual_notice",
+                    "note": "조회 구간에 정기주총 소집공고 없음(임시주총 공고만) — 보수한도 안건 미확보.",
+                    "extraordinary_notice": extraordinary}
+        warnings.append(f"[pay_agenda] 조회 구간({span})에 정기주총 소집공고 없음"
+                        "(종합 조회에서는 사업보고서 승인한도 전년비로 대신함).")
+        return {"status": "no_annual_notice",
+                "note": "조회 구간에 정기주총 소집공고 없음 — 보수한도 안건 미확보."}
+
     for w in (payload.get("warnings") or []):
         warnings.append(f"[notice] {w}")
-    items = ((payload.get("data") or {}).get("compensation") or {}).get("items") or []
+    items = (pdata.get("compensation") or {}).get("items") or []
     director_item = next(
         (it for it in items if "이사" in (it.get("target") or "") and "감사" not in (it.get("target") or "")),
         items[0] if items else None,
     )
+    notice = pdata.get("notice") or {}
+    notice_ref = {
+        "notice_rcept_no": notice.get("rcept_no"),
+        "notice_date": notice.get("disclosure_date"),
+        "meeting_date": (pdata.get("selected_meeting") or {}).get("meeting_date"),
+        "meeting_type": pdata.get("meeting_type"),
+    }
     if not director_item:
         return {"status": "no_agenda",
-                "note": "최근 주총 소집공고에 이사 보수한도 안건이 없거나 파싱 실패."}
+                "note": "최근 정기주총 소집공고에 이사 보수한도 안건이 없거나 파싱 실패.",
+                **notice_ref}
 
     cur = director_item.get("current") or {}
     pri = director_item.get("prior") or {}
@@ -917,6 +974,7 @@ async def _pay_agenda_scope(company_query: str, *, warnings: list[str]) -> dict[
             signal = f"한도 동결/인하({limit_change_pct:+.1f}%)."
 
     return {
+        **notice_ref,
         "agenda_no": director_item.get("number"),
         "agenda_title": director_item.get("title"),
         "proposed_limit_krw": proposed,
@@ -925,7 +983,7 @@ async def _pay_agenda_scope(company_query: str, *, warnings: list[str]) -> dict[
         "limit_change_pct": limit_change_pct,
         "prior_utilization_pct": prior_util,
         "signal": signal,
-        "note": "주총 소집공고 보수한도 안건의 current(올해 제안)/prior(작년 한도·실지급) 컬럼 재사용. "
+        "note": "최근 정기주총 소집공고 보수한도 안건의 current(올해 제안)/prior(작년 한도·실지급) 컬럼 재사용. "
                 "인상률·작년 소진율은 사실 — 찬반 판단은 의결권 자문 도구(proxy_advise_before_meeting)에서 합니다.",
     }
 
@@ -1155,7 +1213,7 @@ async def build_director_board_payload(
             client, corp_code, year, lookback_years=lookback_years, comp_data=None, warnings=warnings),
             "pay_gap", timings)
     if scope in {"pay_agenda", "summary"}:
-        tasks["pay_agenda"] = _timed(_pay_agenda_scope(company_query, warnings=warnings),
+        tasks["pay_agenda"] = _timed(_pay_agenda_scope(company_query, corp_code, warnings=warnings),
                                      "pay_agenda", timings)
     if scope == "attendance":
         # v2(260709): 사업보고서 원문에서 개별 이사 출석률 파싱. summary 기본엔 제외 — 원문 fetch(8MB,
@@ -1313,9 +1371,13 @@ def _collect_data_quality_flags(data: dict[str, Any]) -> list[dict[str, Any]]:
     pa = data.get("pay_agenda") or {}
     if pa and not pa.get("proposed_limit_krw"):
         fb = bool(pa.get("fallback_limit_recent_krw"))
-        flags.append({"scope": "pay_agenda", "kind": "parse_failed",
+        # 정기 소집공고가 없어서(임시주총만) 못 읽은 것은 파싱 실패가 아니다 — kind를 구분한다.
+        no_annual = pa.get("status") == "no_annual_notice"
+        flags.append({"scope": "pay_agenda",
+                      "kind": "no_annual_notice" if no_annual else "parse_failed",
                       "severity": "info" if fb else "warn", "fallback_used": fb,
-                      "detail": "주총 소집공고에서 보수한도 안건 미파싱." +
+                      "detail": ("조회 구간에 정기주총 소집공고 없음(임시주총 공고만)."
+                                 if no_annual else "정기주총 소집공고에서 보수한도 안건 미파싱.") +
                                 (" 사업보고서 승인한도 YoY로 폴백 제공." if fb
                                  else " 폴백도 불가(compensation 연도별 한도 부족).")})
 

--- a/open_proxy_mcp/services/shareholder_meeting.py
+++ b/open_proxy_mcp/services/shareholder_meeting.py
@@ -1644,6 +1644,18 @@ async def _select_notice_candidate(
     return selected, [], basis, None, search_notices
 
 
+async def latest_notice_coverage(corp_code: str, *, lookback_months: int = 12) -> dict[str, Any]:
+    """기본 선택 구간(오늘−lookback ~ 오늘+lead buffer)의 정기/임시 소집공고 존재 여부.
+
+    다른 tool이 「정기 소집공고가 없는데 임시만 있는가」를 물을 때 쓴다(director_board pay_agenda).
+    list.json(E006)·document 캐시를 그대로 타므로 같은 회사를 방금 조회했다면 DART 추가 왕복은 0에
+    가깝다. 반환 shape은 `_meeting_window_coverage`와 같다(has_annual / has_extraordinary /
+    latest_annual / latest_extraordinary …).
+    """
+    window_start, window_end, _ = _selection_window(None, lookback_months=lookback_months)
+    return await _meeting_window_coverage(corp_code, window_start, window_end, months=lookback_months)
+
+
 async def _meeting_window_coverage(
     corp_code: str,
     start_date: date,

--- a/open_proxy_mcp/tools/director_board.py
+++ b/open_proxy_mcp/tools/director_board.py
@@ -246,6 +246,9 @@ def _render(payload: dict[str, Any]) -> str:
     if agenda:
         lines.append("## 보수한도 주총안건 — 올해 제안 vs 작년 실적")
         lines.append("")
+        if agenda.get("notice_rcept_no"):
+            lines.append(f"- 근거 공고: 정기주총 소집공고 rcept {agenda.get('notice_rcept_no')}"
+                         + (f" (회의일 {agenda.get('meeting_date')})" if agenda.get("meeting_date") else ""))
         if not agenda.get("proposed_limit_krw"):
             lines.append(f"- {agenda.get('note')}")
             if agenda.get("fallback_limit_recent_krw"):

--- a/tests/test_director_board_pay_agenda.py
+++ b/tests/test_director_board_pay_agenda.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+"""director_board `pay_agenda`는 **최근 정기주총 소집공고**를 읽는다 — 최근 공고가 아니라.
+
+260904 실측(고려아연): 09-09 임시주총 소집공고가 최신이라 `auto`(임박 회차 우선) 선택이 그 공고를
+읽었고, 3월 정기 제6호 「이사 보수한도 승인(120억)」을 놓친 채 「없거나 파싱 실패 ⚠️」를 냈다.
+애경케미칼도 동일. 보수한도 승인은 정기주총 안건이므로 회차 선택은 정기 공고여야 한다.
+
+network 0콜. list.json / document 경계만 가짜 client로 대체하고(회귀 캐시 원칙: DART 응답 경계),
+shareholder_meeting의 후보 선택 코드는 실제 경로를 탄다. 회의 종류 분류·안건 파싱은 문서별로 고정.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from open_proxy_mcp.services import director_board as db
+from open_proxy_mcp.services import filing_search as fs
+from open_proxy_mcp.services import shareholder_meeting as sm
+from open_proxy_mcp.services.company import CompanyResolution
+from open_proxy_mcp.services.contracts import AnalysisStatus
+
+TODAY = date.today()
+CORP_CODE = "00102858"
+
+# 임시주총(최신, 회의 예정) 가 정기주총(3월, 이미 개최) 뒤에 온다 — 고려아연 260904 모양.
+ANNUAL_NOTICE_DT = TODAY - timedelta(days=180)
+ANNUAL_MEETING = ANNUAL_NOTICE_DT + timedelta(days=19)
+EXTRA_NOTICE_DT = TODAY - timedelta(days=9)
+EXTRA_MEETING = TODAY + timedelta(days=6)
+
+ANNUAL_RCEPT = ANNUAL_NOTICE_DT.strftime("%Y%m%d") + "001616"
+EXTRA_RCEPT = EXTRA_NOTICE_DT.strftime("%Y%m%d") + "000111"
+
+
+def _kdate(d: date) -> str:
+    return f"{d.year}년 {d.month}월 {d.day}일 오전 9시"
+
+
+def _filing(rcept_no: str, rcept_dt: date) -> dict:
+    return {"rcept_no": rcept_no, "report_nm": "주주총회소집공고", "corp_code": CORP_CODE,
+            "rcept_dt": rcept_dt.strftime("%Y%m%d"), "flr_nm": "고려아연"}
+
+
+NOTICE_INFO = {
+    ANNUAL_RCEPT: {"meeting_type": "정기", "meeting_term": "제52기", "is_correction": False,
+                   "datetime": _kdate(ANNUAL_MEETING), "location": "서울"},
+    EXTRA_RCEPT: {"meeting_type": "임시", "meeting_term": "", "is_correction": False,
+                  "datetime": _kdate(EXTRA_MEETING), "location": "서울"},
+}
+
+ANNUAL_COMP_ITEM = {
+    "number": "제6호", "title": "이사 보수한도 승인의 건(120억원)", "target": "이사",
+    "current": {"limitAmount": 12_000_000_000},
+    "prior": {"limitAmount": 10_000_000_000, "actualPaidAmount": 6_750_000_000},
+}
+
+
+class FakeClient:
+    """list.json(E006) + document 경계만 흉내 낸다."""
+
+    def __init__(self, filings: list[dict]):
+        self.filings = filings
+        self.search_calls: list[dict] = []
+        self.calls = 0
+
+    def api_call_snapshot(self):
+        return self.calls
+
+    async def search_filings(self, **kwargs):
+        self.search_calls.append(kwargs)
+        self.calls += 1
+        rows = [f for f in self.filings if kwargs["bgn_de"] <= f["rcept_dt"] <= kwargs["end_de"]]
+        return {"status": "000", "total_count": len(rows), "list": rows}
+
+    async def get_document_cached(self, rcept_no: str):
+        return {"text": f"doc {rcept_no}", "html": ""}
+
+    async def get_company_info(self, _corp_code):
+        return {"acc_mt": "12"}
+
+
+def _install(monkeypatch, filings: list[dict]) -> FakeClient:
+    client = FakeClient(filings)
+    monkeypatch.setattr(sm, "get_dart_client", lambda: client)
+    monkeypatch.setattr(fs, "get_dart_client", lambda: client)
+
+    async def fake_resolve(_query):
+        return CompanyResolution(
+            status=AnalysisStatus.EXACT, query="고려아연",
+            selected={"corp_name": "고려아연", "stock_code": "010130", "corp_code": CORP_CODE},
+            candidates=[])
+
+    async def fake_notice_info(rcept_no, _text, _html):
+        return NOTICE_INFO[rcept_no], "dart_xml"
+
+    async def fake_load(rcept_no, *, scope, soup_cache):
+        info = NOTICE_INFO[rcept_no]
+        items = [ANNUAL_COMP_ITEM] if info["meeting_type"] == "정기" else []
+        return ({"text": f"doc {rcept_no}", "html": "", "meeting_info": info,
+                 "agenda": [], "agenda_valid": True, "board": {"summary": {}},
+                 "compensation": {"items": items, "summary": {"totalItems": len(items)}},
+                 "correction": None}, [], "dart_xml")
+
+    monkeypatch.setattr(sm, "resolve_company_query", fake_resolve)
+    monkeypatch.setattr(sm, "_notice_info_with_fallback", fake_notice_info)
+    monkeypatch.setattr(sm, "_load_notice_bundle_with_fallback", fake_load)
+    return client
+
+
+def test_before_auto_selection_reads_the_upcoming_extraordinary_notice(monkeypatch):
+    """(before) `auto`는 임박한 임시주총 공고를 고른다 — 보수한도 안건이 없는 공고."""
+    _install(monkeypatch, [_filing(EXTRA_RCEPT, EXTRA_NOTICE_DT), _filing(ANNUAL_RCEPT, ANNUAL_NOTICE_DT)])
+    payload = asyncio.run(sm.build_shareholder_meeting_payload("고려아연", scope="compensation"))
+    assert payload["data"]["notice"]["rcept_no"] == EXTRA_RCEPT
+    assert payload["data"]["compensation"]["items"] == []
+
+
+def test_pay_agenda_reads_the_latest_annual_notice_even_when_extraordinary_is_newer(monkeypatch):
+    """(after) pay_agenda는 정기 공고(제6호 120억)를 읽고, 근거 공고 rcept·회의일을 싣는다."""
+    client = _install(monkeypatch, [_filing(EXTRA_RCEPT, EXTRA_NOTICE_DT), _filing(ANNUAL_RCEPT, ANNUAL_NOTICE_DT)])
+    warnings: list[str] = []
+    out = asyncio.run(db._pay_agenda_scope("고려아연", CORP_CODE, warnings=warnings))
+
+    assert out["notice_rcept_no"] == ANNUAL_RCEPT
+    assert out["meeting_type"] == "annual"
+    assert out["meeting_date"] == ANNUAL_MEETING.isoformat()
+    assert out["agenda_no"] == "제6호"
+    assert out["proposed_limit_krw"] == 12_000_000_000
+    assert out["prior_limit_krw"] == 10_000_000_000
+    assert out["limit_change_pct"] == 20.0
+    assert out["prior_utilization_pct"] == 67.5
+    assert not [w for w in warnings if "없거나 파싱" in w]
+    # list.json은 E006(주주총회소집공고)으로 먼저 좁힌다 — 전체 유형 순회 금지.
+    assert client.search_calls and all(c.get("pblntf_detail_ty") == "E006" for c in client.search_calls)
+
+
+def test_pay_agenda_says_so_when_only_an_extraordinary_notice_exists(monkeypatch):
+    """구간에 임시주총 공고만 있으면 파싱 실패가 아니라 「정기 공고 없음」으로 말한다."""
+    _install(monkeypatch, [_filing(EXTRA_RCEPT, EXTRA_NOTICE_DT)])
+    warnings: list[str] = []
+    out = asyncio.run(db._pay_agenda_scope("고려아연", CORP_CODE, warnings=warnings))
+
+    assert out["status"] == "no_annual_notice"
+    assert out["extraordinary_notice"]["notice_rcept_no"] == EXTRA_RCEPT
+    assert out["extraordinary_notice"]["meeting_date"] == EXTRA_MEETING.isoformat()
+    joined = " ".join(warnings)
+    assert "임시주총" in joined and EXTRA_RCEPT in joined and "정기주총 안건" in joined
+
+    flags = db._collect_data_quality_flags({"pay_agenda": out})
+    pa_flags = [f for f in flags if f["scope"] == "pay_agenda"]
+    assert pa_flags and pa_flags[0]["kind"] == "no_annual_notice"
+
+
+def test_pay_agenda_reports_no_notice_at_all(monkeypatch):
+    """소집공고가 하나도 없으면 임시주총 언급 없이 「정기 공고 없음」."""
+    _install(monkeypatch, [])
+    warnings: list[str] = []
+    out = asyncio.run(db._pay_agenda_scope("고려아연", CORP_CODE, warnings=warnings))
+    assert out["status"] == "no_annual_notice"
+    assert "extraordinary_notice" not in out
+    assert any("정기주총 소집공고 없음" in w for w in warnings)
+    assert not any("임시주총" in w for w in warnings)
+
+
+def test_parse_failure_on_annual_notice_is_still_parse_failed(monkeypatch):
+    """정기 공고는 찾았는데 안건이 없으면 종전대로 no_agenda(parse_failed) — 근거 공고는 남긴다."""
+    _install(monkeypatch, [_filing(ANNUAL_RCEPT, ANNUAL_NOTICE_DT)])
+
+    async def empty_load(rcept_no, *, scope, soup_cache):
+        return ({"text": "", "html": "", "meeting_info": NOTICE_INFO[rcept_no], "agenda": [],
+                 "agenda_valid": True, "board": {"summary": {}},
+                 "compensation": {"items": [], "summary": {}}, "correction": None}, [], "dart_xml")
+
+    monkeypatch.setattr(sm, "_load_notice_bundle_with_fallback", empty_load)
+    warnings: list[str] = []
+    out = asyncio.run(db._pay_agenda_scope("고려아연", CORP_CODE, warnings=warnings))
+    assert out["status"] == "no_agenda"
+    assert out["notice_rcept_no"] == ANNUAL_RCEPT
+    flags = db._collect_data_quality_flags({"pay_agenda": out})
+    assert [f["kind"] for f in flags if f["scope"] == "pay_agenda"] == ["parse_failed"]

--- a/wiki/tools/director_board.md
+++ b/wiki/tools/director_board.md
@@ -159,9 +159,17 @@ Pass2 나머지만 `birth_ym` 매칭(그 값이 남은 후보군에서 유일할
 기준이라, `compensation` scope의 사업보고서 기반 소진율과 연도 기준·집계 정의가 다를 수 있음(둘 다
 사실, 출처 다름). 찬반 판단 자체는 하지 않음(→ [[proxy_advise_before_meeting]]).
 
-**주의**: pay_agenda는 `year` 파라미터를 무시하고 항상 **최근 주총 소집공고**를 본다(주총은 연 1회라
-'올해 안건' 자체가 최신). 소집공고 안건 파싱에 실패하면 **compensation 표 승인한도 YoY로 폴백**하고
-출처를 밝힌다.
+**주의**: pay_agenda는 `year` 파라미터를 무시하고 **최근 정기주총 소집공고**를 본다(보수한도 승인은
+정기주총 안건이라 '올해 안건' 자체가 최신). "최근 공고"가 아니다 — 임시주총이 정기 뒤에 끼는 회사에서
+`auto`(임박 회차 우선)로 고르면 보수한도 안건이 없는 임시 공고를 읽는다(2026-09-04 실측 고려아연:
+09-09 임시주총 공고가 최신이라 3월 정기 제6호 120억 한도를 놓치고 `no_agenda`. 애경케미칼도 동일).
+그래서 `shareholder_meeting_notice(meeting_type="annual", lookback_months=13)` 경로로 list.json을
+`pblntf_detail_ty=E006`으로 먼저 좁힌 뒤 본문 정기/임시 표기로 고른다. 13개월인 이유: 12개월은 360일이라
+매년 같은 날 나오는 정기 공고가 성수기 직전에 며칠씩 구간 밖으로 밀린다. 구간에 정기 공고가 없고 임시만
+있으면 `status=no_annual_notice` + warnings에 임시주총 회의일·rcept를 적고(`data_quality_flags`
+kind `no_annual_notice`, 파싱 실패와 구분), 결과엔 근거 공고 `notice_rcept_no`·`meeting_date`를 싣는다.
+소집공고 안건 파싱에 실패하면 **compensation 표 승인한도 YoY로 폴백**하고 출처를 밝힌다(summary scope만 —
+pay_agenda 단독 scope는 compensation 표를 안 받으므로 폴백 없음).
 
 **`no_agenda`는 대개 정상 폴백이다** — 보수한도 안건 자체가 없거나(그 해 이사선임만), "규정 신설"류
 정관변경이라 금액이 없거나, 승인안건이 아닌 후보자 참고표인 경우다. `client.py`의 IMAGE_NOTICE
@@ -403,11 +411,13 @@ sequenceDiagram
 | `hmvAuditIndvdlBySttus` | 개인별 보수(5억+) |
 | `unrstExctvMendngSttus` | 미등기 집행임원 인원·연급여총액·1인평균 |
 | `empSttus` | 직원 부문·성별 인원·평균급여 (pay_gap 분모) |
-| shareholder_meeting notice (재사용) | 보수한도 주총안건 current/prior (pay_agenda) |
+| shareholder_meeting notice (재사용, `meeting_type=annual`) | 최근 정기주총 보수한도 안건 current/prior (pay_agenda) |
 | 사업보고서 원문 (document.xml) | 각주 본문 해소 + 이사회 출석률(attendance) + 보수 산정기준 VIII-2(pay_criteria) |
 | `hmvAuditIndvdlBySttus` (재사용) | pay_criteria 하이브리드 교차검증(파서 Σ vs API 공식총액) |
 
 ## 변경 이력
+- 2026-09-04: `pay_agenda` 회차 선택을 최근 공고(auto) → **최근 정기주총 소집공고**(annual, E006, 13개월)로.
+  임시주총만 있으면 `no_annual_notice` + warnings. 근거 공고 rcept·회의일 노출.
 - 2026-08-06: 검증 census·발견 경위 서술을 private storage 로 이관(경계 규칙 [[wiki_schema]] 0.0).
 - 2026-07-30: roster 현재 명단을 최신 정기보고서 사다리로 + `changes_since_last_annual` 신설.
 - 2026-07-13: `pay_criteria` scope 신설(원문 VIII-2 파서 + API 하이브리드 교차검증) ·


### PR DESCRIPTION
## Summary

Fix `pay_agenda` scope to read the **latest annual (정기) shareholder meeting notice** instead of the most recent notice of any type. This prevents reading extraordinary (임시) meeting notices that lack director compensation agenda items, which are only present in annual meetings.

## Problem

When a company holds an extraordinary meeting after its annual meeting (e.g., Koryoazen on 2026-09-04), the `auto` selection strategy picks the most recent notice. This causes `pay_agenda` to read the extraordinary notice, which has no compensation agenda, resulting in `no_agenda` status and missing the annual meeting's director compensation limit proposal (e.g., 120억 won in agenda #6).

## Changes

**`director_board.py`**
- Add `corp_code` parameter to `_pay_agenda_scope()` to enable fallback coverage checks
- Add `_PAY_AGENDA_LOOKBACK_MONTHS = 13` constant (12 months + 1 month buffer for date drift)
- Pass `meeting_type="annual"` and `lookback_months=13` to `build_shareholder_meeting_payload()` to filter for annual notices only
- When no annual notice is found but extraordinary notices exist, return `status="no_annual_notice"` with extraordinary notice details in response and warnings
- Include notice reference fields (`notice_rcept_no`, `meeting_date`, `meeting_type`) in all response paths
- Update `_collect_data_quality_flags()` to distinguish `no_annual_notice` (info severity) from `parse_failed` (warn severity)

**`shareholder_meeting.py`**
- Add `latest_notice_coverage()` function to check annual/extraordinary notice availability in a given window (used by `pay_agenda` to explain why only extraordinary notices exist)

**`tools/director_board.py`**
- Display notice reference (rcept_no, meeting_date) in output when available

**`wiki/tools/director_board.md`**
- Document the change: `pay_agenda` now uses `meeting_type="annual"` with 13-month lookback
- Explain why 13 months (360 days can shift annual notices outside 12-month window near peak season)
- Clarify distinction between `no_annual_notice` (no annual notice in window) and `no_agenda` (annual notice found but no compensation agenda)
- Note that `pay_agenda` scope alone has no fallback (compensation table not fetched)

## Implementation Details

- Searches use `pblntf_detail_ty=E006` (shareholder meeting notice) filter first, then classify by meeting type in document text (reuses `shareholder_meeting` shared path)
- 13-month lookback accommodates annual notices that drift a few days before peak season due to fixed calendar dates
- When extraordinary notice exists but no annual notice, warnings include meeting date and rcept_no to explain the gap
- Notice reference fields (`notice_rcept_no`, `meeting_date`, `meeting_type`) are included in all response paths for traceability

https://claude.ai/code/session_01PY3wqGkx65o9RjDVStjcr2