### PR TITLE
feat(asset_holdings): report·year 인자 — 반기·분기·과거 기수 기준, 첨부정정 건너뛰기

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 OpenProxy MCP의 버전별 변경 이력입니다. [English](RELEASE_NOTES_ENG.md)
 
+## beta — 2026-09-07
+
+### `asset_holdings` 에 `report`·`year`
+
+종전에는 최신 사업보고서 하나로 고정이었습니다. 이제 `report`(annual·half·quarter·q1·q3·latest)와 `year`(사업연도)로 반기·분기·과거 기수 기준의 보유 자산을 볼 수 있고, 첨부만 고친 `[첨부정정]` 공시는 건너뜁니다. 분기·반기는 주석 항목이 얇아 명세가 없을 수 있다는 경고가 붙습니다.
+
 ## beta — 2026-09-06
 
 ### 확장 훅

--- a/docs/RELEASE_NOTES_ENG.md
+++ b/docs/RELEASE_NOTES_ENG.md
@@ -2,6 +2,12 @@
 
 Version history for OpenProxy MCP. [한국어](RELEASE_NOTES.md)
 
+## beta — 2026-09-07
+
+### `report` and `year` for `asset_holdings`
+
+Previously fixed to the latest annual report. `report` (annual, half, quarter, q1, q3, latest) and `year` (fiscal year) now select half-year, quarterly, or past-year holdings; attachment-only corrections (`[첨부정정]`) are skipped. Quarterly and half-year reports carry thinner notes, so the response warns that detail schedules may be absent.
+
 ## beta — 2026-09-06
 
 ### Extension hooks

--- a/open_proxy_mcp/services/asset_holdings.py
+++ b/open_proxy_mcp/services/asset_holdings.py
@@ -272,8 +272,52 @@ async def _market_cap(stock_code: str):
     return mk["common_mktcap"], {"shares": mk.get("list_shrs"), "close": mk["price"], "date": mk.get("date")}
 
 
+#: report 인자 → (최신 후보 period 라벨, 사업연도 지정 시 reprt_code 순서). filing_section(opm-ext)과 같은 어휘.
+_REPORT_KIND = {
+    "annual": ("annual", ["11011"]), "half": ("half", ["11012"]),
+    "quarter": ("quarter", ["11014", "11013"]), "q1": ("quarter", ["11013"]), "q3": ("quarter", ["11014"]),
+    "latest": ("latest", ["11011", "11012", "11014", "11013"]),
+}
+_CODE_BY_NAME = (("사업보고서", "11011"), ("반기보고서", "11012"), ("분기보고서", None))
+
+
+def _reprt_code_of(rept: dict, fallback: str = "11011") -> str:
+    """보고서 이름 → DART reprt_code. 분기보고서는 기수 라벨 월로 1분기(11013)/3분기(11014)를 가른다
+    (12월 결산 기준 — 결산월이 다르면 호출 쪽이 빈 결과에서 다른 코드로 한 번 더 간다)."""
+    nm = rept.get("report_nm") or ""
+    for token, code in _CODE_BY_NAME:
+        if token in nm:
+            if code:
+                return code
+            m = re.search(r"\((\d{4})\.(\d{2})\)", nm)
+            month = int(m.group(2)) if m else 3
+            return "11013" if month <= 6 else "11014"
+    return fallback
+
+
+async def _pick_periodic_report(client, corp_code: str, report: str = "annual", year: int = 0) -> tuple[dict | None, str, str]:
+    """(보고서, reprt_code, 오류메시지). 260907: 종전엔 사업보고서 첫 후보 고정이라 「2024년 말 자산」「반기 기준
+    담보」를 못 잡았고 `[첨부정정]`(첨부만 고친 것, 본문 없음)을 집을 수 있었다. filing_section 과 같은 규칙으로 맞춘다."""
+    kind = _REPORT_KIND.get((report or "annual").strip().lower())
+    if kind is None:
+        return None, "", f"report 는 annual·half·quarter·q1·q3·latest 중 하나 (받은 값: {report})"
+    period, codes = kind
+    if year:
+        reps = []
+        for code in codes:
+            reps += await _bd._find_report_for_bsns_year(client, corp_code, str(year), code)
+        reps.sort(key=lambda r: r.get("rcept_dt", ""), reverse=True)
+    else:
+        reps = await _bd._find_report_candidates(client, corp_code, period)
+    reps = [r for r in reps if "첨부정정" not in (r.get("report_nm") or "")]
+    if not reps:
+        return None, "", f"{year or '최신'} {report} 정기보고서 없음"
+    rept = reps[0]
+    return rept, _reprt_code_of(rept, codes[0]), ""
+
+
 async def _build_asset_holdings_payload_impl(company: str, scope: str = "summary",
-                                       format: str = "md") -> dict[str, Any]:
+                                       format: str = "md", report: str = "annual", year: int = 0) -> dict[str, Any]:
     client = get_dart_client()
     q = (company or "").strip()
     if not q:
@@ -290,19 +334,25 @@ async def _build_asset_holdings_payload_impl(company: str, scope: str = "summary
     name = corp.get("corp_name") or company
     warnings: list[str] = []
 
-    cands = await _bd._find_report_candidates(client, cc, "annual")
-    if not cands:
-        return {"tool": "asset_holdings", "status": "no_filing", "subject": name,
-                "warnings": ["정기(사업)보고서 없음"]}
-    rept = cands[0]
+    rept, reprt_code, err = await _pick_periodic_report(client, cc, report, int(year or 0))
+    if rept is None:
+        return {"tool": "asset_holdings", "status": "no_filing" if "없음" in err else "invalid", "subject": name,
+                "warnings": [err]}
     year = (_YEAR.search(rept.get("report_nm") or "") or [None, str(today_kst().year - 1)])[1]
+    if reprt_code != "11011":
+        warnings.append(f"{rept.get('report_nm', '').strip()} 기준 — 분기·반기보고서는 사업보고서보다 주석 항목이 얇아 "
+                        "토지 공정가치·담보·우발 명세가 없을 수 있다.")
 
     data: dict[str, Any] = {"company": name, "ticker": isu, "report_nm": rept.get("report_nm"),
-                            "rcept_no": rept.get("rcept_no"), "year": year, "scope": scope}
+                            "rcept_no": rept.get("rcept_no"), "year": year, "reprt_code": reprt_code, "scope": scope}
 
     async def _fin_acnt(fs):
         try:
-            return await client.get_fnltt_singl_acnt_all(cc, year, "11011", fs)
+            out = await client.get_fnltt_singl_acnt_all(cc, year, reprt_code, fs)
+            if not (out or {}).get("list") and reprt_code in ("11013", "11014"):
+                # 결산월이 12월이 아니면 분기 코드가 반대일 수 있다 — 한 번 바꿔 본다
+                out = await client.get_fnltt_singl_acnt_all(cc, year, "11013" if reprt_code == "11014" else "11014", fs)
+            return out
         except DartClientError:
             return {}
 
@@ -335,7 +385,7 @@ async def _build_asset_holdings_payload_impl(company: str, scope: str = "summary
         if is_reit:
             warnings.append("REIT 추정(사명 기준) — 투자부동산이 본업이라 잉여자산에서 제외")
         try:
-            otr = await client.get_other_corp_investment(cc, year, "11011")
+            otr = await client.get_other_corp_investment(cc, year, reprt_code)
         except DartClientError:
             otr = {}
         sec = await _safe_getdoc(client, rept["rcept_no"])

--- a/open_proxy_mcp/tools/asset_holdings.py
+++ b/open_proxy_mcp/tools/asset_holdings.py
@@ -130,14 +130,15 @@ def _render(p: dict) -> str:
 def register_tools(mcp):
 
     @mcp.tool()
-    async def asset_holdings(company: str, scope: str = "summary", format: str = "md") -> str:
+    async def asset_holdings(company: str, scope: str = "summary", format: str = "md", report: str = "annual", year: int = 0) -> str:
         """desc: 회사가 **보유한 자산**(투자부동산·지분증권·현금성·관계기업 지분)을 감사 연결재무제표 계정에서 뽑고, **시총 대비 청산가치(NAV) 커버리지**로 자산저평가주를 스크리닝. "시총보다 보유 자산이 값진가"에 답합니다.
         when: 자산주·NAV·청산가치·지주사 할인·숨은 부동산/지분 분석. "이 회사 자산 뭐 있어? 자산 대비 싸?"(summary) · 원문 명세로 직접 확인(detail). 전사 밸류(PER/PBR)는 `price_multiple_data`, 재무비율은 `financial_metrics`.
         scope: **`summary`(기본)** — 자산을 목적버킷(현금성/환금성증권·재테크형/우호제휴지분/지배관계사지분/투자용부동산/본업자산)으로 분류해 "재테크형·부동산 자산주형·지주사 할인형·우호지분형" 한 줄 서사(`asset_story`) + 세부 계정 + **상장 보유지분 시가마크** + 담보·우발 haircut 플래그 + 시총 대비 배수(잉여자산/지분NAV, 금융업은 미제공) / **`detail`** — III.주석 원문 markdown(토지 원가vs공정가치·지분증권·담보·우발) — summary에서 haircut 플래그가 뜨거나 숫자 원문을 직접 확인하고 싶을 때.
+        report: `annual`(기본)·`half`·`quarter`·`q1`·`q3`·`latest` — 어느 정기보고서 기준인지. `year`=사업연도(예 2024)를 주면 그 해 보고서(전년 비교). 분기·반기는 주석 항목이 얇아 detail 명세가 없을 수 있음. `[첨부정정]` 은 건너뜀.
         rule: 구조화(계정·타법인출자)는 숫자, 주석(토지gap·담보·우발)은 **원문 markdown 반환→caller가 읽어 판단**. 시가마크는 상장 보유지분만(비상장은 장부가). **배수는 부채 미차감 gross → PBR 병용**. 담보·우발은 NAV에서 차감해야 정확(detail로 확인). **금융업(KSIC 64/65/66)은 투자자산=본업**이라 금융 리그 라벨.
         ref: price_multiple_data, financial_metrics, business_details, treasury_share
         """
-        payload = await build_asset_holdings_payload(company, scope=scope)
+        payload = await build_asset_holdings_payload(company, scope=scope, report=report, year=year)
         if format == "json":
             return as_pretty_json(payload)
         return _render(payload)

--- a/tests/test_asset_holdings_report_param.py
+++ b/tests/test_asset_holdings_report_param.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""asset_holdings 의 report·year — 종전엔 사업보고서 첫 후보 고정(첨부정정도 집음). network 0."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from open_proxy_mcp.services import asset_holdings as A
+
+
+def _reps():
+    return [{"rcept_no": "20260313001226", "report_nm": "[첨부정정]사업보고서 (2025.12)", "rcept_dt": "20260313"},
+            {"rcept_no": "20260312001399", "report_nm": "사업보고서 (2025.12)", "rcept_dt": "20260312"}]
+
+
+@pytest.fixture
+def fakes(monkeypatch):
+    calls = []
+    async def cands(client, corp_code, period):
+        calls.append(("cands", period)); return _reps() if period in ("annual", "latest") else [
+            {"rcept_no": "20260814003992", "report_nm": "반기보고서 (2026.06)", "rcept_dt": "20260814"}]
+    async def by_year(client, corp_code, bsns_year, reprt_code):
+        calls.append(("year", bsns_year, reprt_code))
+        nm = {"11011": "사업보고서", "11012": "반기보고서", "11013": "분기보고서", "11014": "분기보고서"}[reprt_code]
+        mm = {"11011": "12", "11012": "06", "11013": "03", "11014": "09"}[reprt_code]
+        return [{"rcept_no": f"{bsns_year}{reprt_code}00001", "report_nm": f"{nm} ({bsns_year}.{mm})", "rcept_dt": f"{bsns_year}{mm}15"}]
+    monkeypatch.setattr(A._bd, "_find_report_candidates", cands)
+    monkeypatch.setattr(A._bd, "_find_report_for_bsns_year", by_year)
+    return calls
+
+
+def test_default_annual_skips_attachment_corrections(fakes):
+    rept, code, err = asyncio.run(A._pick_periodic_report(object(), "00126380"))
+    assert rept["rcept_no"] == "20260312001399" and code == "11011" and err == ""
+
+
+def test_half_and_year_map_to_the_right_lookup_and_code(fakes):
+    rept, code, _ = asyncio.run(A._pick_periodic_report(object(), "00126380", "half"))
+    assert rept["report_nm"].startswith("반기보고서") and code == "11012" and fakes[-1] == ("cands", "half")
+    rept, code, _ = asyncio.run(A._pick_periodic_report(object(), "00126380", "q3", 2025))
+    assert fakes[-1] == ("year", "2025", "11014") and code == "11014"
+    rept, code, _ = asyncio.run(A._pick_periodic_report(object(), "00126380", "q1", 2025))
+    assert code == "11013"
+
+
+def test_bad_report_value_is_an_error_not_a_guess(fakes):
+    rept, code, err = asyncio.run(A._pick_periodic_report(object(), "00126380", "monthly"))
+    assert rept is None and "annual·half·quarter" in err
+
+
+def test_reprt_code_from_report_name():
+    assert A._reprt_code_of({"report_nm": "사업보고서 (2025.12)"}) == "11011"
+    assert A._reprt_code_of({"report_nm": "[기재정정]반기보고서 (2026.06)"}) == "11012"
+    assert A._reprt_code_of({"report_nm": "분기보고서 (2026.03)"}) == "11013"
+    assert A._reprt_code_of({"report_nm": "분기보고서 (2025.09)"}) == "11014"

--- a/wiki/tools/asset_holdings.md
+++ b/wiki/tools/asset_holdings.md
@@ -8,7 +8,7 @@ related_disclosures: [사업보고서]
 related_concepts: [순현금, 시가총액, 연결-별도, PER-PBR, 단위-표기-규약]
 related_lessons: [markdown-primary-anchor-260719]
 created: 2026-07-20
-updated: 2026-09-06
+updated: 2026-09-07
 ---
 
 # asset_holdings
@@ -43,6 +43,15 @@ updated: 2026-09-06
   summary에서 haircut 플래그가 뜨거나 숫자 원문을 직접 확인하고 싶을 때.
 - 예: `asset_holdings("영풍")` → 지주사 숨은 지분가치(코리아써키트 장부 820억→시가 7,736억,
   미실현 +6,916억) · `asset_holdings("천일고속", scope="detail")` → 소규모기업(OFS) 원문 명세.
+
+### 시점 인자 (260907)
+| 인자 | 값 | 뜻 |
+|---|---|---|
+| `report` | `annual`(기본) · `half` · `quarter` · `q1` · `q3` · `latest` | 어느 정기보고서 기준인지. 재무제표 API 의 `reprt_code`(11011/11012/11013/11014)도 이에 맞춰 부른다 |
+| `year` | 사업연도(예 2024) | 그 해 보고서(전년 비교). 없으면 최신 |
+
+기본은 사업보고서 — 분기·반기는 주석 항목이 얇아 `detail` 의 토지 공정가치·담보·우발 명세가 없을 수 있고, 그때 응답에 경고가 붙는다.
+`[첨부정정]` 은 첨부만 고친 공시라 건너뛴다. 예: 「2024년 말 자산」 → `year=2024` · 「상반기 기준」 → `report="half"`.
 
 ## 출력 (ToolEnvelope.data)
 - `rcept_no`: 읽은 보고서 접수번호(260906 추가). `detail` 의 부재 갈래(`extraction_failed`·`cross_reference`·발췌 있는 부재)에는 확장 훅([[extension-hooks]])이 있으면 원문 위치 한 줄이 붙는다.


### PR DESCRIPTION
## 무엇을
`asset_holdings(company, scope, report="annual", year=0)`. `report` 는 annual·half·quarter·q1·q3·latest, `year` 는 사업연도. 선택 규칙은 `_pick_periodic_report()` — `[첨부정정]` 건너뜀, `year` 가 있으면 `_find_report_for_bsns_year`, 없으면 `_find_report_candidates`. 재무제표 API(`get_fnltt_singl_acnt_all`·`get_other_corp_investment`)의 `reprt_code` 를 보고서 종류에서 유도한다(사업 11011 · 반기 11012 · 분기는 기수 라벨 월로 11013/11014, 빈 결과면 반대 코드 한 번 더). 응답 `reprt_code` 추가, 분기·반기면 경고 한 줄.

## 왜
종전엔 사업보고서 첫 후보 고정이라 「2024년 말 자산」「상반기 기준 담보」를 못 잡았고, 첨부만 고친 `[첨부정정]` 이 최신이면 그걸 집었다. 도구 인자 점검(260907)에서 시점 인자가 없는 도구 셋 중 첫 번째.

## 검증
- `uv run pytest -q` 전체 통과(신규 4건: 첨부정정 건너뜀·half/year 매핑·잘못된 값 오류·보고서명→코드). 실패 1건은 git 미추적 로컬 스크립트 검사로 무관.
- 실측(in-process MCP): 삼성전자 기본 = 사업보고서(2025.12) 잉여자산 127조 · `report="half"` = 반기(2026.06) 191조 · `year=2024` = 사업보고서(2024.12) 114조 · 삼성화재 `latest` = 반기, 금융업 라벨.
- wiki `tools/asset_holdings.md` 시점 인자 절·변경 이력, 릴리즈 노트 한/영. lint·카탈로그·documentation contract 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)