### PR TITLE
feat(provisional_earnings): months·start_date·end_date 노출 — 과거 분기 잠정실적

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 OpenProxy MCP의 버전별 변경 이력입니다. [English](RELEASE_NOTES_ENG.md)
 
+## beta — 2026-09-07
+
+### `provisional_earnings` 에 `months`·`start_date`·`end_date`
+
+최근 6개월의 최신 1건만 보던 것을, 개월 수나 공시일 창(YYYYMMDD)으로 과거 분기의 잠정실적을 집을 수 있게 했습니다. 서비스에는 있던 인자를 도구에 노출했습니다.
+
 ## beta — 2026-09-06
 
 ### 확장 훅

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -4,15 +4,13 @@ OpenProxy MCP의 버전별 변경 이력입니다. [English](RELEASE_NOTES_ENG.m
 
 ## beta — 2026-09-07
 
-<<<<<<< HEAD
 ### `provisional_earnings` 에 `months`·`start_date`·`end_date`
 
 최근 6개월의 최신 1건만 보던 것을, 개월 수나 공시일 창(YYYYMMDD)으로 과거 분기의 잠정실적을 집을 수 있게 했습니다. 서비스에는 있던 인자를 도구에 노출했습니다.
-=======
+
 ### `asset_holdings` 에 `report`·`year`
 
 종전에는 최신 사업보고서 하나로 고정이었습니다. 이제 `report`(annual·half·quarter·q1·q3·latest)와 `year`(사업연도)로 반기·분기·과거 기수 기준의 보유 자산을 볼 수 있고, 첨부만 고친 `[첨부정정]` 공시는 건너뜁니다. 분기·반기는 주석 항목이 얇아 명세가 없을 수 있다는 경고가 붙습니다.
->>>>>>> origin/main
 
 ## beta — 2026-09-06
 

--- a/docs/RELEASE_NOTES_ENG.md
+++ b/docs/RELEASE_NOTES_ENG.md
@@ -2,6 +2,12 @@
 
 Version history for OpenProxy MCP. [한국어](RELEASE_NOTES.md)
 
+## beta — 2026-09-07
+
+### `months`, `start_date`, `end_date` for `provisional_earnings`
+
+Instead of only the latest filing within six months, a month count or a filing-date window (YYYYMMDD) now selects a past quarter's provisional results. The parameters existed in the service and are now exposed on the tool.
+
 ## beta — 2026-09-06
 
 ### Extension hooks

--- a/docs/RELEASE_NOTES_ENG.md
+++ b/docs/RELEASE_NOTES_ENG.md
@@ -4,15 +4,13 @@ Version history for OpenProxy MCP. [한국어](RELEASE_NOTES.md)
 
 ## beta — 2026-09-07
 
-<<<<<<< HEAD
 ### `months`, `start_date`, `end_date` for `provisional_earnings`
 
 Instead of only the latest filing within six months, a month count or a filing-date window (YYYYMMDD) now selects a past quarter's provisional results. The parameters existed in the service and are now exposed on the tool.
-=======
+
 ### `report` and `year` for `asset_holdings`
 
 Previously fixed to the latest annual report. `report` (annual, half, quarter, q1, q3, latest) and `year` (fiscal year) now select half-year, quarterly, or past-year holdings; attachment-only corrections (`[첨부정정]`) are skipped. Quarterly and half-year reports carry thinner notes, so the response warns that detail schedules may be absent.
->>>>>>> origin/main
 
 ## beta — 2026-09-06
 

--- a/open_proxy_mcp/services/provisional_earnings.py
+++ b/open_proxy_mcp/services/provisional_earnings.py
@@ -368,7 +368,8 @@ async def build_provisional_earnings_payload(
     if not rept:
         return ToolEnvelope(tool="provisional_earnings", status=AnalysisStatus.NO_FILING,
                             subject=corp.get("corp_name", ""),
-                            warnings=[f"최근 {months}개월 영업(잠정)실적 공시 없음"]).to_dict()
+                            warnings=[(f"{bgn_de}~{end_de} 창에 영업(잠정)실적 공시 없음" if (start_date or end_date)
+                                       else f"최근 {months}개월 영업(잠정)실적 공시 없음") + " — 창을 넓히거나(months·start_date) financial_metrics 확정치로"]).to_dict()
     url = f"https://dart.fss.or.kr/dsaf001/main.do?rcpNo={rept['rcept_no']}"
     try:
         doc = await client.get_document_cached(rept["rcept_no"])

--- a/open_proxy_mcp/tools/provisional_earnings.py
+++ b/open_proxy_mcp/tools/provisional_earnings.py
@@ -5,6 +5,8 @@
 """
 from __future__ import annotations
 
+import re
+
 from open_proxy_mcp.services.provisional_earnings import build_provisional_earnings_payload
 from open_proxy_mcp.services.contracts import as_pretty_json
 
@@ -83,13 +85,18 @@ def _render(p: dict) -> str:
 def register_tools(mcp):
 
     @mcp.tool()
-    async def provisional_earnings(company: str, format: str = "md") -> str:
+    async def provisional_earnings(company: str, format: str = "md", months: int = 6, start_date: str = "", end_date: str = "") -> str:
         """desc: DART 영업(잠정)실적(공정공시 I002)과 결산 잠정치(I001)에서 **잠정 매출·영업이익·순이익**과 회계연도 기준 비교율을 추출. 정기보고서 확정치보다 **먼저 나오는 가장 빠른 실적 신호**.
         when: 최신 분기 실적을 정기보고서(financial_metrics 확정치) 나오기 전에 볼 때. **잠정치**(감사 전)라 확정과 다를 수 있음 — 확정 재무비율은 `financial_metrics`.
         rule: 재무형(매출·영업이익 표)은 구조화 반환. 자동차 판매대수 등 **비재무형**은 raw 마크다운(kind=non_financial). 연결/별도 basis·실적기간·단위 명시. 값은 원문 그대로(원 단위 정규화), 잠정치.
+        window: 기본 최근 `months`=6개월 안의 **가장 최근** 잠정실적 1건. 과거 분기를 보려면 `start_date`·`end_date`(YYYYMMDD)로 공시일 창을 좁힌다 — 예 2025년 3분기 잠정실적은 `start_date="20251001", end_date="20251115"`. 창 안에 여러 건이면 최신 1건.
         ref: financial_metrics, screener, price_multiple_data
         """
-        payload = await build_provisional_earnings_payload(company)
+        for nm, v in (("start_date", start_date), ("end_date", end_date)):
+            if v and not re.fullmatch(r"\d{8}", v):
+                return f"{nm} 는 YYYYMMDD 8자리여야 합니다 (받은 값: {v})"
+        payload = await build_provisional_earnings_payload(company, months=max(1, int(months or 6)),
+                                                           start_date=start_date or None, end_date=end_date or None)
         if format == "json":
             return as_pretty_json(payload)
         return _render(payload)

--- a/tests/test_provisional_earnings_window.py
+++ b/tests/test_provisional_earnings_window.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""provisional_earnings 의 months·start_date·end_date — 서비스엔 있었지만 도구에 안 노출돼 「작년 3분기 잠정실적」을 못 집었다(260907). network 0."""
+from __future__ import annotations
+
+import asyncio
+
+from open_proxy_mcp.server import mcp
+from open_proxy_mcp.tools import provisional_earnings as T
+
+
+def _call(**a):
+    async def go():
+        r = await mcp.call_tool("provisional_earnings", a)
+        return "".join(getattr(c, "text", "") for c in (r if isinstance(r, list) else r.content))
+    return asyncio.run(go())
+
+
+def test_window_args_pass_through_to_the_service(monkeypatch):
+    seen = {}
+    async def fake(company, *, months=6, start_date=None, end_date=None, format="md"):
+        seen.update(company=company, months=months, start_date=start_date, end_date=end_date)
+        return {"status": "no_filing", "subject": company, "warnings": ["x"], "data": {}}
+    monkeypatch.setattr(T, "build_provisional_earnings_payload", fake)
+    _call(company="삼성전자", start_date="20251001", end_date="20251115")
+    assert seen == {"company": "삼성전자", "months": 6, "start_date": "20251001", "end_date": "20251115"}
+    _call(company="삼성전자", months=18)
+    assert seen["months"] == 18 and seen["start_date"] is None
+    assert "YYYYMMDD" in _call(company="삼성전자", start_date="2025-10-01")

--- a/wiki/tools/provisional_earnings.md
+++ b/wiki/tools/provisional_earnings.md
@@ -8,7 +8,7 @@ related_disclosures: [사업보고서, 분기보고서]
 related_concepts: [연결-별도, 단위-표기-규약, 시점-제약]
 related_decisions: [ksic-sector-mapping]
 created: 2026-07-19
-updated: 2026-09-06
+updated: 2026-09-07
 ---
 
 ## 한 줄
@@ -31,6 +31,14 @@ DART **영업(잠정)실적(I001 결산잠정치·I002 공정공시)** 에서 �
 ## 사용법
 - `provisional_earnings(company, format="md")` — 최신 영업잠정실적(최근 6개월 내).
 - 예: `provisional_earnings("삼성전자")` · `provisional_earnings("현대자동차")`.
+
+### 시점 인자 (260907)
+| 인자 | 기본 | 뜻 |
+|---|---|---|
+| `months` | 6 | 최근 N개월 안의 가장 최근 잠정실적 1건 |
+| `start_date`·`end_date` | — | 공시일 창(YYYYMMDD). 과거 분기를 집을 때 — 2025년 3분기 잠정실적은 `start_date="20251001", end_date="20251115"` |
+
+서비스(`build_provisional_earnings_payload`)엔 원래 있던 인자를 도구에 노출한 것. 창 안에 없으면 경고가 창 범위를 말한다.
 
 ## 왜 필요한가 (financial_metrics와 차이)
 - **잠정 ≠ 확정**: financial_metrics는 정기보고서 확정치(fnlttSinglAcnt, 감사 후). 잠정실적은 **자가 공시**(감사 전, 분기말 ~7일 뒤). 확정치와 다를 수 있음.
@@ -67,6 +75,8 @@ DART **영업(잠정)실적(I001 결산잠정치·I002 공정공시)** 에서 �
 - colspan 확장으로 헤더 셀이 중복 표기(가독성 경미, 수치 왜곡 없음).
 
 ## 변경 이력
+
+- 2026-09-07: `months`·`start_date`·`end_date` 를 도구 인자로 노출(서비스엔 있었음). 「없음」 경고가 실제 창을 말한다.
 - 2026-09-06: **[기재정정] 표 변형 서식** — 구분 열 없이 라벨과 기간이 한 칸에 오는 「- 매출액(당해실적)」·
   「매출액(당기실적)」, 셀이 「당해실적: 478,413 전기대비증감율(%): …」 한 줄 요약인 꼴. 캐시 157건 실측에서
   정정 4건이 전부 headline 이 비어 `non_financial` 로 나갔다 → `_label_key`(기간 꼬리 분리, 누계 행 제외)


### PR DESCRIPTION
## 무엇을
`provisional_earnings(company, format, months=6, start_date="", end_date="")`. 서비스 `build_provisional_earnings_payload` 에 이미 있던 세 인자를 도구에 노출. `start_date`·`end_date` 는 YYYYMMDD 검증. 창 안에 없을 때의 경고가 실제 창 범위를 말하고 다음 경로(창 넓히기·`financial_metrics` 확정치)를 적는다.

## 왜
최근 6개월의 최신 1건만 볼 수 있어 「2025년 3분기 잠정실적」처럼 과거 분기를 못 집었다. 도구 인자 점검(260907)에서 시점 인자가 없는 도구 셋 중 두 번째.

## 검증
- `uv run pytest -q` 전체 통과(신규 1파일 3검사: 인자 전달·months·형식 오류). 실패 1건은 git 미추적 로컬 스크립트 검사로 무관.
- 실측(in-process): 삼성전자 기본 / `20251001~20251115` / `20250101~20250131` 창이 각기 다른 공시를 잡음.
- wiki `tools/provisional_earnings.md` 시점 인자 절·변경 이력, 릴리즈 노트 한/영. lint·카탈로그 통과.

## 참고(이 PR 범위 밖)
잠정실적 머리의 「N 사업연도 M분기」 라벨이 실제 분기와 어긋나 보이는 건이 있다(삼성전자 2025-10 공시가 「2026 사업연도 1분기」). 라벨 파생 로직을 따로 볼 것.

🤖 Generated with [Claude Code](https://claude.com/claude-code)