### PR TITLE
feat(price_multiple_data): as_of — firm·market·sector 과거 시점 밸류에이션

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 OpenProxy MCP의 버전별 변경 이력입니다. [English](RELEASE_NOTES_ENG.md)
 
+## beta — 2026-09-07
+
+### `price_multiple_data` 에 `as_of`
+
+「작년 말 PER」처럼 과거 시점을 물을 수 있습니다. `scope=firm` 은 주간 스냅샷에서 기준일 이하 가장 최근 값(PER·PBR·시총, 배당수익률 제외), `market`·`sector` 는 기준일 이하 스냅샷으로 표를 그립니다. 비우면 종전과 같이 최신입니다.
+
 ## beta — 2026-09-06
 
 ### 확장 훅

--- a/docs/RELEASE_NOTES_ENG.md
+++ b/docs/RELEASE_NOTES_ENG.md
@@ -2,6 +2,12 @@
 
 Version history for OpenProxy MCP. [한국어](RELEASE_NOTES.md)
 
+## beta — 2026-09-07
+
+### `as_of` for `price_multiple_data`
+
+Past-dated questions such as "PER at last year-end" are now answerable. `scope=firm` reads the latest weekly snapshot at or before the date (PER, PBR, market cap; no dividend yield), while `market` and `sector` draw their tables from the snapshot at or before the date. Empty means latest, as before.
+
 ## beta — 2026-09-06
 
 ### Extension hooks

--- a/open_proxy_mcp/services/price_multiple_data.py
+++ b/open_proxy_mcp/services/price_multiple_data.py
@@ -371,7 +371,7 @@ async def build_market_val_payload(format: str = "md", as_of: str | None = None)
         past = [h for h in hist if h["snap_dd"] <= as_of]
         if not past:
             return {"tool": "price_multiple_data", "status": "no_data", "subject": "시장 밸류에이션",
-                    "warnings": [f"as_of {as_of} 이하 스냅샷 없음 — 가장 이른 스냅샷은 {hist[-1]['snap_dd']}."]}
+                    "warnings": [f"기준일 {as_of} 이하 스냅샷 없음 — 가장 이른 스냅샷은 {hist[-1]['snap_dd']}."]}
         latest_dd = past[0]["snap_dd"]
     else:
         latest_dd = hist[0]["snap_dd"]
@@ -428,7 +428,7 @@ async def build_sector_val_payload(company: str = "", format: str = "md",
                 "warnings": [_DB_ERROR_PAYLOAD_WARN]}
     if not rows:
         return {"tool": "price_multiple_data", "status": "no_data", "subject": "산업별 밸류에이션",
-                "warnings": [f"as_of {as_of} 이하 산업별 스냅샷 없음." if as_of else "opm_val_market 비어있음 — market_val_weekly 배치 미실행."]}
+                "warnings": [f"기준일 {as_of} 이하 산업별 스냅샷 없음." if as_of else "opm_val_market 비어있음 — market_val_weekly 배치 미실행."]}
     as_of = rows[0][0]
     sectors = [{"market": r[1], "sector": r[2], "label": r[3], "n": r[4], "cap_krw": r[5],
                 "per_ttm": r[6] and round(r[6], 2), "pbr_mrq": r[7] and round(r[7], 2),
@@ -730,7 +730,7 @@ async def build_firm_at_payload(company: str, as_of: str) -> dict[str, Any]:
     if not pts:
         first = (d.get("series") or [{}])[0].get("asof")
         return {"tool": "price_multiple_data", "status": "no_data", "subject": hist.get("subject", company),
-                "warnings": [f"as_of {as_of} 이하 주간 점 없음 — 곡선의 첫 점은 {first}. 현재 값은 scope=firm."]}
+                "warnings": [f"기준일 {as_of} 이하 주간 점 없음 — 곡선의 첫 점은 {first}. 기준일을 비우면 현재 값."]}
     p = pts[-1]
     return {"tool": "price_multiple_data", "status": "ok", "subject": hist.get("subject", company),
             "data": {"scope": "firm_at", "ticker": d.get("ticker"), "as_of_requested": as_of, "as_of": p["asof"],

--- a/open_proxy_mcp/services/price_multiple_data.py
+++ b/open_proxy_mcp/services/price_multiple_data.py
@@ -339,8 +339,18 @@ def _attach_div(row: dict, key: tuple, act: dict, fwd: dict) -> None:
         row["fwd_div_n_dps"] = f.get("n_dps")
 
 
-async def build_market_val_payload(format: str = "md") -> dict[str, Any]:
-    """시장 전체(KOSPI/KOSDAQ) 시총가중 밸류에이션 — 최신 + 주간 히스토리(opm_val_market)."""
+def _norm_as_of(as_of) -> str | None:
+    """YYYYMMDD 또는 YYYY-MM-DD → YYYYMMDD. 빈 값은 None. 형식이 틀리면 ValueError."""
+    v = (as_of or "").strip().replace("-", "")
+    if not v:
+        return None
+    if not (len(v) == 8 and v.isdigit()):
+        raise ValueError(f"as_of 는 YYYYMMDD 또는 YYYY-MM-DD 여야 합니다 (받은 값: {as_of})")
+    return v
+
+
+async def build_market_val_payload(format: str = "md", as_of: str | None = None) -> dict[str, Any]:
+    """시장 전체(KOSPI/KOSDAQ) 시총가중 밸류에이션 — 최신(또는 as_of 이하 최근 스냅샷) + 주간 히스토리(opm_val_market)."""
     rows = await asyncio.to_thread(_pg_rows,
         "SELECT snap_dd, market, per_fy0, per_ttm, pbr_fy0, pbr_mrq, cap, ni_ttm, eq, cap_pref, ni_fy0 "
         "FROM opm_val_market WHERE sector='_ALL' AND scheme='market' ORDER BY snap_dd DESC, market")
@@ -356,14 +366,22 @@ async def build_market_val_payload(format: str = "md") -> dict[str, Any]:
              "cap_krw": r[6], "ni_ttm_krw": r[7], "eq_krw": r[8],
              "cap_pref_krw": r[9] if len(r) > 9 else None,
              "ni_fy0_krw": r[10] if len(r) > 10 else None} for r in rows]
-    latest_dd = hist[0]["snap_dd"]
+    if as_of:
+        # 260907: 과거 시점 — as_of 이하 가장 최근 주간 스냅샷. 히스토리는 그대로 다 준다.
+        past = [h for h in hist if h["snap_dd"] <= as_of]
+        if not past:
+            return {"tool": "price_multiple_data", "status": "no_data", "subject": "시장 밸류에이션",
+                    "warnings": [f"as_of {as_of} 이하 스냅샷 없음 — 가장 이른 스냅샷은 {hist[-1]['snap_dd']}."]}
+        latest_dd = past[0]["snap_dd"]
+    else:
+        latest_dd = hist[0]["snap_dd"]
     latest = [h for h in hist if h["snap_dd"] == latest_dd]
     # 260831: 배당수익률 두 벌을 같은 표에 얹는다. 키는 (market, 'ALL').
     div_act, div_fwd, div_ruler = await _div_yield_map("market")
     for h in latest:
         _attach_div(h, (h["market"], "ALL"), div_act, div_fwd)
     return {"tool": "price_multiple_data", "status": "ok", "subject": "시장 밸류에이션(KOSPI·KOSDAQ)",
-            "data": {"scope": "market", "as_of": latest_dd,
+            "data": {"scope": "market", "as_of": latest_dd, "as_of_requested": as_of,
                      "latest": latest,
                      "history": hist,
                      "div_yield_ruler": div_ruler or None,
@@ -389,25 +407,28 @@ _SECTOR_SCHEMES = {
 
 
 async def build_sector_val_payload(company: str = "", format: str = "md",
-                                   scheme: str = "wics_industry") -> dict[str, Any]:
+                                   scheme: str = "wics_industry", as_of: str | None = None) -> dict[str, Any]:
     """산업별 시총가중 밸류에이션 — 최신 스냅샷 + 섹터 히스토리(opm_val_market).
     company 지정 시 그 기업의 섹터를 함께 표시. scheme 으로 분류 축 선택."""
     scheme = (scheme or "wics_industry").strip().lower()
     if scheme not in _SECTOR_SCHEMES:
         return {"tool": "price_multiple_data", "status": "invalid", "subject": "산업별 밸류에이션",
                 "warnings": [f"scheme '{scheme}' 없음 — {' / '.join(_SECTOR_SCHEMES)} 중 선택."]}
+    # 260907: as_of 가 있으면 그 이하 가장 최근 스냅샷 (과거 시점 비교)
+    sub = "SELECT MAX(snap_dd) FROM opm_val_market WHERE sector != '_ALL' AND scheme=%s" + (" AND snap_dd <= %s" if as_of else "")
+    params: tuple = (scheme, scheme, as_of) if as_of else (scheme, scheme)
     rows = await asyncio.to_thread(_pg_rows,
         "SELECT snap_dd, market, sector, label, n, cap, per_ttm, pbr_mrq, per_fy0, pbr_fy0, "
         "ni_fy0, ni_ttm FROM opm_val_market "
         "WHERE sector != '_ALL' AND scheme=%s "
-        "AND snap_dd=(SELECT MAX(snap_dd) FROM opm_val_market WHERE sector != '_ALL' AND scheme=%s) "
-        "ORDER BY market, cap DESC", (scheme, scheme))
+        f"AND snap_dd=({sub}) "
+        "ORDER BY market, cap DESC", params)
     if rows is None:
         return {"tool": "price_multiple_data", "status": "db_error", "subject": "산업별 밸류에이션",
                 "warnings": [_DB_ERROR_PAYLOAD_WARN]}
     if not rows:
         return {"tool": "price_multiple_data", "status": "no_data", "subject": "산업별 밸류에이션",
-                "warnings": ["opm_val_market 비어있음 — market_val_weekly 배치 미실행."]}
+                "warnings": [f"as_of {as_of} 이하 산업별 스냅샷 없음." if as_of else "opm_val_market 비어있음 — market_val_weekly 배치 미실행."]}
     as_of = rows[0][0]
     sectors = [{"market": r[1], "sector": r[2], "label": r[3], "n": r[4], "cap_krw": r[5],
                 "per_ttm": r[6] and round(r[6], 2), "pbr_mrq": r[7] and round(r[7], 2),
@@ -695,6 +716,28 @@ def _month_end_summary(series: list[dict], months: int = 12) -> list[dict]:
         prev_q = pt.get("pit_q")
         out.append(pt)
     return out
+
+
+async def build_firm_at_payload(company: str, as_of: str) -> dict[str, Any]:
+    """종목의 **과거 시점** 배수 — firm_history 의 전 구간 주간 곡선(krx_weekly 2015~ × DART 재무 PIT)에서 as_of 이하
+    가장 최근 점 하나. `opm_val_firm` 은 최근 10주만 있어 과거로 못 간다(260907 실측: 20260703~20260904).
+    scope=firm 의 실시간 계산(DART×krx)은 과거로 못 가므로 곡선으로 답한다."""
+    hist = await build_firm_history_payload(company, format="json")
+    if hist.get("status") != "ok":
+        return hist
+    d = hist["data"]
+    pts = [p for p in (d.get("series") or []) if str(p.get("asof", "")) <= as_of]
+    if not pts:
+        first = (d.get("series") or [{}])[0].get("asof")
+        return {"tool": "price_multiple_data", "status": "no_data", "subject": hist.get("subject", company),
+                "warnings": [f"as_of {as_of} 이하 주간 점 없음 — 곡선의 첫 점은 {first}. 현재 값은 scope=firm."]}
+    p = pts[-1]
+    return {"tool": "price_multiple_data", "status": "ok", "subject": hist.get("subject", company),
+            "data": {"scope": "firm_at", "ticker": d.get("ticker"), "as_of_requested": as_of, "as_of": p["asof"],
+                     "market": d.get("market"), "sector": d.get("sector") or d.get("induty"),
+                     "pit_fy": p.get("pit_fy"), "pit_q": p.get("pit_q"), "cap_krw": p.get("cap_krw"),
+                     "per_fy0": p.get("per_fy0"), "per_ttm": p.get("per_ttm"), "pbr_fy0": p.get("pbr"), "pbr_mrq": p.get("pbr_mrq")},
+            "warnings": [f"주간 스냅샷(주 마지막 거래일 {p['asof']}) · 재무는 그 시점까지 공시된 값(FY0={p.get('pit_fy')}, 분기={p.get('pit_q')}) · 배당수익률은 과거 시점 미제공."]}
 
 
 async def build_firm_history_payload(company: str, format: str = "md") -> dict[str, Any]:

--- a/open_proxy_mcp/tools/price_multiple_data.py
+++ b/open_proxy_mcp/tools/price_multiple_data.py
@@ -10,7 +10,9 @@ from open_proxy_mcp.services.price_multiple_data import (
     build_valuation_payload,
     build_market_val_payload,
     build_sector_val_payload,
+    build_firm_at_payload,
     build_firm_history_payload,
+    _norm_as_of,
 )
 from open_proxy_mcp.market_codes import to_label as mkt_label
 
@@ -175,6 +177,19 @@ def _render_sector(p: dict[str, Any]) -> str:
     for w in p.get("warnings", []):
         lines.append(f"> {w}")
     return "\n".join(lines)
+
+
+def _render_firm_at(p: dict[str, Any]) -> str:
+    d = p["data"]
+    def f(v): return "-" if v is None else f"{v:.2f}"
+    cap = d.get("cap_krw"); cap_s = f"{cap/1e12:,.1f}조" if cap and cap >= 1e12 else (f"{cap/1e8:,.0f}억" if cap else "-")
+    L = [f"# {p['subject']} — {d['as_of'][:4]}-{d['as_of'][4:6]}-{d['as_of'][6:]} 기준 밸류에이션 (주간 스냅샷)", "",
+         f"- 요청 기준일 {d['as_of_requested']} → 스냅샷 {d['as_of']} · {d.get('market','')} · 섹터 {d.get('sector','') or '-'}", "",
+         "| 지표 | 값 |", "|---|---|", f"| 시총(보통주) | {cap_s} |", f"| PER (FY0) | {f(d.get('per_fy0'))} |", f"| PER (TTM) | {f(d.get('per_ttm'))} |",
+         f"| PBR (FY0) | {f(d.get('pbr_fy0'))} |", f"| PBR (MRQ) | {f(d.get('pbr_mrq'))} |"]
+    for w in p.get("warnings") or []:
+        L.append(f"\n> {w}")
+    return "\n".join(L)
 
 
 def _render_firm_history(p: dict[str, Any]) -> str:
@@ -342,15 +357,20 @@ def register_tools(mcp):
 
     @mcp.tool()
     async def price_multiple_data(company: str = "", scope: str = "firm", format: str = "md",
-                        scheme: str = "wics_industry") -> str:
+                        scheme: str = "wics_industry", as_of: str = "") -> str:
         """desc: 상대가치 밸류에이션 — 기업 심층(PER·PBR·배당수익률) + 시장 전체·산업별·종목 히스토리(주간 스냅샷). 한국 표준(연결, 지배주주 귀속). 비KRW 기능통화 자동 KRW 환산(ECOS), 스케일가드, N/M 게이팅.
         when: "PER/PBR 얼마"·"싼가 비싼가"(scope=firm) / "코스피·코스닥 전체 밸류"(market) / "업종별 PER·PBR"·"섹터 대비 어디"(sector, company 지정 시 소속 섹터 비교) / "밸류 추이"(firm_history) / **"이 수치 근거·계산 과정이 뭐야?"(explain — company 지정 시 실제 값 대입 계산, 미지정 시 방법론·기준·출처 전문)**. 재무 펀더멘탈 자체는 financial_metrics, 배당 상세는 dividend_disclosure.
         rule: scope=firm(기본, company 필수) = 실시간 DART 재무 × krx_weekly 시세 — **PER=보통주 시총÷지배순이익 · PBR=보통주 시총÷지배자본(MRQ)** (260823 전환: 주가÷EPS 는 액면분할·병합 때 옛 주식수 기준 EPS 와 새 주가가 섞여 틀렸다). 주식수가 상쇄돼 조정성 이벤트에 불변이고 **스냅샷 스코프와 정의가 같다**. EPS(공시 기본주당이익)·BPS 는 회사 공식값이라 인풋으로 함께 싣되 배수 산출엔 안 쓴다. 대가 — 가중평균이 아니고(연중 유상증자 시 공시 EPS 와 벌어짐), 분자는 보통주 시총인데 분모엔 우선주 몫이 포함돼 소폭 하향 편향. 분모≤0·완전자본잠식=N/M. scope=market/sector/firm_history = Supabase 주간 스냅샷(opm_val_market·opm_val_market·opm_val_firm, market_val_weekly 배치가 갱신) — PER=**Σ보통주 시총**÷Σ지배순이익(시총가중 조화평균, 우선주 시총은 제외·cap_pref 별도 노출), 시총 기반이라 수정주가 조정 불변. 섹터 분류=KSIC 하이브리드. firm과 스냅샷 방법론 차이(보통주 주가 vs 총시총) 有 — 각 출력에 명시. 값 raw KRW int(_krw), % float(_pct). **scope=market 과 scope=sector(scheme=wics_sector) 에는 시총가중 배당수익률이 함께 실린다**(260831) — 확정=div_yield_hist(사업연도 12월결산 확정 DPS, 연 1회) · 선행=fwd_agg(애널리스트 추정 DPS). PER·PBR 과 **출처 표도 기준일도 모집단도 다르다.** 분모 두 벌(all=무배당 포함 시장 관행값 / payers=배당주만)을 나란히 내는데, 코스닥은 두 값이 두 배 차이라 반드시 같이 읽어야 한다 — 눌림의 절반은 배당력이 아니라 배당하는 회사가 적다는 구성 차이다. PER 과 달리 적자여도 배당이 있으면 값이 난다. scheme=ksic·wics_industry 에는 안 붙는다(집계 버킷이 WICS 대분류다).
+        as_of: YYYYMMDD(또는 YYYY-MM-DD) 과거 시점. firm → 그 시점 이하 가장 최근 **주간 스냅샷**(opm_val_firm)의 PER·PBR·시총(배당수익률 없음) / market·sector → 그 시점 이하 스냅샷. 「작년 말 PER」「2024년 12월 코스피 PBR」. 비우면 최신.
         status: ok / invalid / not_found(우선주는 보통주 코드로) / unlisted / no_financials / no_data(배치 미실행).
        
         ref: financial_metrics, dividend_disclosure, corp_gov_report, evidence
         """
         sc = (scope or "firm").strip().lower()
+        try:
+            asof = _norm_as_of(as_of)
+        except ValueError as exc:
+            return str(exc)
         if sc in ("explain", "method", "basis"):  # 수치 근거 — 계산 과정·기준·출처 (유저 "근거가 뭐야?")
             if not (company or "").strip():
                 return _METHODOLOGY  # 방법론 전문 — API 0콜
@@ -361,11 +381,13 @@ def register_tools(mcp):
                 return _render_status(payload)
             return _render_explain_firm(payload)
         if sc == "market":
-            payload = await build_market_val_payload(format=format)
+            payload = await build_market_val_payload(format=format, as_of=asof)
         elif sc == "sector":
-            payload = await build_sector_val_payload(company, format=format, scheme=scheme)
+            payload = await build_sector_val_payload(company, format=format, scheme=scheme, as_of=asof)
         elif sc in ("firm_history", "history"):
             payload = await build_firm_history_payload(company, format=format)
+        elif sc == "firm" and asof:
+            payload = await build_firm_at_payload(company, asof)
         elif sc == "firm":
             payload = await build_valuation_payload(company, format=format)
         else:  # 오타("markets" 등)를 조용히 firm으로 보내면 의도 밖 DART 콜 — 명시 거절(QA)
@@ -376,6 +398,8 @@ def register_tools(mcp):
         if payload.get("status") != "ok":
             return _render_status(payload)
         scope_out = payload.get("data", {}).get("scope")
+        if scope_out == "firm_at":
+            return _render_firm_at(payload)
         if scope_out == "market":
             return _render_market(payload)
         if scope_out == "sector":

--- a/tests/test_price_multiple_as_of.py
+++ b/tests/test_price_multiple_as_of.py
@@ -40,7 +40,7 @@ def test_sector_sql_bounds_the_snapshot_when_as_of_given(monkeypatch):
     monkeypatch.setattr(S, "_pg_rows", fake_rows)
     p = asyncio.run(S.build_sector_val_payload(scheme="ksic", as_of="20251231"))
     assert "snap_dd <= %s" in seen["sql"] and seen["params"] == ("ksic", "ksic", "20251231")
-    assert p["status"] == "no_data" and "as_of 20251231" in p["warnings"][0]
+    assert p["status"] == "no_data" and "기준일 20251231" in p["warnings"][0]
     asyncio.run(S.build_sector_val_payload(scheme="ksic"))
     assert "snap_dd <= %s" not in seen["sql"] and seen["params"] == ("ksic", "ksic")
 

--- a/tests/test_price_multiple_as_of.py
+++ b/tests/test_price_multiple_as_of.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""price_multiple_data 의 as_of — 과거 시점 배수. 형제 trading_data 엔 있었고 여기엔 없었다(260907). network·DB 0."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from open_proxy_mcp.services import price_multiple_data as S
+from open_proxy_mcp.server import mcp
+
+ROWS = [("20260904", "KOSPI", 12.0, 11.0, 1.1, 1.0, 100, 1, 1, None, None), ("20260904", "KOSDAQ", 30.0, 25.0, 2.0, 1.9, 10, 1, 1, None, None),
+        ("20251226", "KOSPI", 10.0, 9.5, 1.0, 0.9, 90, 1, 1, None, None), ("20251226", "KOSDAQ", 28.0, 24.0, 1.8, 1.7, 9, 1, 1, None, None),
+        ("20200131", "KOSPI", 15.0, 14.0, 0.9, 0.8, 50, 1, 1, None, None)]
+
+
+def test_norm_as_of_accepts_both_forms_and_rejects_garbage():
+    assert S._norm_as_of("2025-12-31") == "20251231" and S._norm_as_of("20251231") == "20251231" and S._norm_as_of("") is None
+    with pytest.raises(ValueError):
+        S._norm_as_of("2025/12/31")
+
+
+def test_market_as_of_picks_the_latest_snapshot_at_or_before(monkeypatch):
+    monkeypatch.setattr(S, "_pg_rows", lambda sql, params=(): ROWS)
+    async def no_div(scheme): return {}, {}, {}
+    monkeypatch.setattr(S, "_div_yield_map", no_div)
+    p = asyncio.run(S.build_market_val_payload(as_of="20251231"))
+    assert p["status"] == "ok" and p["data"]["as_of"] == "20251226" and p["data"]["as_of_requested"] == "20251231"
+    assert {h["market"] for h in p["data"]["latest"]} == {"KOSPI", "KOSDAQ"} and len(p["data"]["history"]) == 5
+    p = asyncio.run(S.build_market_val_payload(as_of="20190101"))
+    assert p["status"] == "no_data" and "가장 이른 스냅샷은 20200131" in p["warnings"][0]
+    assert asyncio.run(S.build_market_val_payload())["data"]["as_of"] == "20260904"          # 없으면 최신
+
+
+def test_sector_sql_bounds_the_snapshot_when_as_of_given(monkeypatch):
+    seen = {}
+    def fake_rows(sql, params=()):
+        seen["sql"], seen["params"] = sql, params
+        return []
+    monkeypatch.setattr(S, "_pg_rows", fake_rows)
+    p = asyncio.run(S.build_sector_val_payload(scheme="ksic", as_of="20251231"))
+    assert "snap_dd <= %s" in seen["sql"] and seen["params"] == ("ksic", "ksic", "20251231")
+    assert p["status"] == "no_data" and "as_of 20251231" in p["warnings"][0]
+    asyncio.run(S.build_sector_val_payload(scheme="ksic"))
+    assert "snap_dd <= %s" not in seen["sql"] and seen["params"] == ("ksic", "ksic")
+
+
+def test_firm_as_of_picks_the_curve_point_at_or_before(monkeypatch):
+    async def fake_hist(company, format="md"):
+        return {"tool": "price_multiple_data", "status": "ok", "subject": "삼성전자", "data": {"scope": "firm_history", "ticker": "005930", "market": "KOSPI", "sector": "C26",
+                "series": [{"asof": "20251219", "pit_fy": 2024, "pit_q": "2025Q3", "cap_krw": 3.1e14, "per_fy0": 12.0, "pbr": 1.2, "per_ttm": 11.0, "pbr_mrq": 1.1},
+                           {"asof": "20251226", "pit_fy": 2024, "pit_q": "2025Q3", "cap_krw": 3.2e14, "per_fy0": 12.34, "pbr": 1.21, "per_ttm": 11.5, "pbr_mrq": 1.15},
+                           {"asof": "20260102", "pit_fy": 2024, "pit_q": "2025Q3", "cap_krw": 3.3e14, "per_fy0": 13.0, "pbr": 1.3, "per_ttm": 12.0, "pbr_mrq": 1.2}]}}
+    monkeypatch.setattr(S, "build_firm_history_payload", fake_hist)
+    async def go(a):
+        r = await mcp.call_tool("price_multiple_data", a)
+        return "".join(getattr(c, "text", "") for c in (r if isinstance(r, list) else r.content))
+    out = asyncio.run(go({"company": "삼성전자", "scope": "firm", "as_of": "2025-12-31"}))
+    assert out.startswith("# 삼성전자 — 2025-12-26 기준 밸류에이션 (주간 스냅샷)")
+    assert "| PER (FY0) | 12.34 |" in out and "| PBR (MRQ) | 1.15 |" in out and "요청 기준일 20251231 → 스냅샷 20251226" in out
+    assert "FY0=2024, 분기=2025Q3" in out and "배당수익률은 과거 시점 미제공" in out
+    assert "곡선의 첫 점은 20251219" in asyncio.run(go({"company": "삼성전자", "scope": "firm", "as_of": "20200101"}))
+    assert "YYYYMMDD" in asyncio.run(go({"company": "삼성전자", "as_of": "작년말"}))

--- a/wiki/tools/price_multiple_data.md
+++ b/wiki/tools/price_multiple_data.md
@@ -8,7 +8,7 @@ data_source: [DART financial_metrics 4EP(요약), DART company.json(업종·결�
 related_disclosures: [사업보고서, 분기보고서]
 related_concepts: [배당수익률, 당기순이익, ROE, PER-PBR, 시가총액, 연결-별도, 단위-표기-규약]
 created: 2026-07-05
-updated: 2026-09-04
+updated: 2026-09-07
 ---
 
 # price_multiple_data
@@ -39,6 +39,11 @@ price_multiple_data(scope="firm_history", company="삼성전자")  # 종목 PER/
 - "반도체 업종 밸류" → sector: KSIC 섹터별 PER/PBR 표
 - "두산밥캣 섹터 평균 대비 싸? 비싸?" → sector + company: 기업 vs 소속 섹터 비교 + 섹터 시계열
 - "배당수익률 얼마?" → firm: 현재가 기준(시장·섹터 집계 배당수익률은 market/sector)
+
+### 과거 시점 `as_of` (260907)
+`as_of="20251231"`(또는 `2025-12-31`). `scope=firm` 이면 실시간 계산 대신 `firm_history` 의 **전 구간 주간 곡선**(krx_weekly 2015~ × DART 재무 PIT)에서
+기준일 이하 가장 최근 점의 PER(FY0·TTM)·PBR(FY0·MRQ)·시총을 준다 — 배당수익률은 과거 시점 미제공. `market`·`sector` 는
+기준일 이하 스냅샷으로 표를 그린다. 형제 도구 `trading_data` 의 `as_of` 와 같은 뜻. 비우면 종전과 같이 최신.
 
 ## 입력 인자
 | 인자 | 타입 | 필수 | 설명 | 기본값 |
@@ -262,6 +267,8 @@ sequenceDiagram
   한국은행 ECOS를 야후 폴백 대신 정본 유지 · 우선주 총시총 합산.
 
 ## 변경 이력
+
+- 2026-09-07: `as_of` — firm(firm_history 주간 곡선에서 점 선택 · `opm_val_firm` 은 최근 10주만 있어 안 씀)·market·sector 의 과거 시점. 응답 `as_of_requested`.
 - 2026-08-06: 수정 경위 서술을 현재형 설계 근거로 정리(경계 규칙 [[wiki_schema]] 0.0).
 - 2026-07-14: FY 라벨 하드코딩 제거(`_latest_annual_fy()` 파생).
 - 2026-07-09: 주간 cron 이 sector 행의 per_fy0/pbr_fy0·ni_ttm·eq 도 채우도록.


### PR DESCRIPTION
## 무엇을
`price_multiple_data(…, as_of="")`. YYYYMMDD 또는 YYYY-MM-DD.
- `scope=market`: 이미 받아 둔 주간 히스토리에서 as_of 이하 가장 최근 스냅샷으로 표. 히스토리는 그대로.
- `scope=sector`: `MAX(snap_dd)` 부속질의에 `snap_dd <= %s` 상한.
- `scope=firm`: 실시간 계산(DART×krx)은 과거로 못 가므로 `firm_history` 의 전 구간 주간 곡선에서 as_of 이하 점 하나 — PER(FY0·TTM)·PBR(FY0·MRQ)·시총, 그 시점 PIT 재무(FY0·분기) 표기. 배당수익률은 과거 시점 미제공. 새 렌더러 `_render_firm_at`.
- 응답 `as_of_requested`. 비우면 종전과 같이 최신.

## 왜
형제 `trading_data` 에는 `as_of` 가 있는데 여기엔 없어 「작년 말 PER」「2024년 12월 코스피 PBR」을 못 답했다. 도구 인자 점검(260907)의 셋 중 마지막.

## 리뷰 포인트
- `opm_val_firm` 은 최근 10주(20260703~20260904)만 있어 firm 의 과거 시점 원천으로 쓰지 않았다(처음엔 그렇게 짰다가 실측에서 빈 결과).
- firm as_of 는 `build_firm_history_payload` 를 호출하므로 비용은 `scope=firm_history` 와 같다(DART 재무 몇 콜).

## 검증
- `uv run pytest -q` 전체 통과(신규 4건: as_of 정규화·market 선택/없음·sector SQL 상한·firm 점 선택·렌더). 실패 1건은 git 미추적 로컬 스크립트 검사로 무관.
- 실측(DB·DART): 삼성전자 `as_of=2025-12-31` → 2025-12-26 스냅샷 PER(TTM) 21.28·PBR(MRQ) 1.72·시총 692.6조 · 리노공업 `20240630` → 2024-06-28 · market/sector `20241231` → 20241227 스냅샷.
- wiki `tools/price_multiple_data.md` 과거 시점 절·변경 이력, 릴리즈 노트 한/영. lint·카탈로그 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)