### PR TITLE
fix: 「못 찾았다」 안내를 12개 진입점에서 정본으로 통일 + 죽어 있던 AMBIGUOUS 분기 되살리기

### DIFF
--- a/open_proxy_mcp/services/asset_holdings.py
+++ b/open_proxy_mcp/services/asset_holdings.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from open_proxy_mcp.clock import today_kst
 from open_proxy_mcp.dart.fx import fiscal_year_end_date, fx_to_krw, statement_currency
 
-from open_proxy_mcp.services.contracts import declare_weak_resolution
+from open_proxy_mcp.services.contracts import declare_weak_resolution, AnalysisStatus
 
 import re
 import sqlite3
@@ -238,7 +238,11 @@ async def _mark_listed_stakes(client, holdings: list[dict], doc_text: str,
 from open_proxy_mcp.dart.client import get_dart_client  # noqa: E402
 from open_proxy_mcp.services import business_details as _bd  # noqa: E402
 from open_proxy_mcp.services import price_multiple_data as _val  # noqa: E402
-from open_proxy_mcp.services.company import _safe_company_info, resolve_company_query  # noqa: E402
+from open_proxy_mcp.services.company import (COMPANY_LOOKUP_NEXT_ACTION,  # noqa: E402
+                                             _safe_company_info,
+                                             company_ambiguous_warning,
+                                             company_not_found_warning,
+                                             resolve_company_query)
 
 _YEAR = re.compile(r"\((\d{4})\.\d{2}\)")
 _FIN_SEC = ("64", "65", "66")
@@ -328,8 +332,16 @@ async def _build_asset_holdings_payload_impl(company: str, scope: str = "summary
         scope = "summary"
     res = await resolve_company_query(q)
     if not res.selected:
-        return {"tool": "asset_holdings", "status": "not_found", "subject": company,
-                "warnings": [f"'{company}' 식별 실패 — 종목코드나 정확한 회사명으로 재시도."]}
+        # 이 파일의 반환 계약은 ToolEnvelope 가 아니라 생 dict 다(status 도 문자열) — 그대로 두고
+        # **문구만** 정본으로 바꾼다. 후보가 여럿이면 그 후보를 버리지 않고 싣는다.
+        _amb = res.status == AnalysisStatus.AMBIGUOUS
+        return {"tool": "asset_holdings", "status": "ambiguous" if _amb else "not_found",
+                "subject": company,
+                "data": {"query": company,
+                         "candidates": [c for c in (res.candidates or [])][:10]},
+                "next_actions": [COMPANY_LOOKUP_NEXT_ACTION],
+                "warnings": [company_ambiguous_warning(company, res.candidates) if _amb
+                             else company_not_found_warning(company)]}
     corp = res.selected
     cc, isu = corp["corp_code"], corp.get("stock_code") or corp.get("ticker")
     name = corp.get("corp_name") or company

--- a/open_proxy_mcp/services/business_details.py
+++ b/open_proxy_mcp/services/business_details.py
@@ -1703,7 +1703,10 @@ async def build_business_details_payload(company_query: str, period: str = "late
     period 기본="latest"(사업·반기·분기 중 최신=최신 데이터). "annual"/"quarterly"로 명시 override.
     bsns_year+reprt_code 둘 다 지정 시 특정 과거 시점(시계열 추이용)을 조회 — period보다 우선."""
     from open_proxy_mcp.services.contracts import ToolEnvelope, AnalysisStatus
-    from open_proxy_mcp.services.company import resolve_company_query
+    from open_proxy_mcp.services.company import (COMPANY_LOOKUP_NEXT_ACTION,
+                                                 company_ambiguous_warning,
+                                                 company_not_found_warning,
+                                                 resolve_company_query)
     from open_proxy_mcp.dart.client import get_dart_client
     from open_proxy_mcp.services.segment_candidates import find_segment_candidates
 
@@ -1741,10 +1744,19 @@ async def build_business_details_payload(company_query: str, period: str = "late
 
     resolution = await resolve_company_query(company_query)
     _lap("resolve")
+    # AMBIGUOUS 를 **먼저** 잡는다 — 그건 selected 가 항상 None 이라 아래 가드에 먼저 걸려
+    # 후보를 손에 쥐고도 「찾지 못했다」로 답해 왔다.
+    if resolution.status == AnalysisStatus.AMBIGUOUS:
+        return ToolEnvelope(
+            tool="business_details", status=AnalysisStatus.AMBIGUOUS, subject=company_query,
+            data={"query": company_query, "candidates": resolution.candidates, "timings_ms": T},
+            warnings=[company_ambiguous_warning(company_query, resolution.candidates)],
+            next_actions=[COMPANY_LOOKUP_NEXT_ACTION]).to_dict()
     if resolution.status == AnalysisStatus.ERROR or not resolution.selected:
         return ToolEnvelope(tool="business_details", status=resolution.status,
                             subject=company_query, data={"timings_ms": T},
-                            warnings=["회사 식별 실패"]).to_dict()
+                            warnings=[company_not_found_warning(company_query)],
+                            next_actions=[COMPANY_LOOKUP_NEXT_ACTION]).to_dict()
     corp = resolution.selected
     client = get_dart_client()
 

--- a/open_proxy_mcp/services/company.py
+++ b/open_proxy_mcp/services/company.py
@@ -547,6 +547,31 @@ def company_not_found_warning(query: str, *, listed_only: bool = False) -> str:
     )
 
 
+#: 회사 미해결 안내의 **다음 경로**. 문구를 tool 마다 지어내지 않게 상수로 둔다.
+COMPANY_LOOKUP_NEXT_ACTION = "company tool 로 회사 식별 확인"
+
+
+def company_ambiguous_warning(query: str, candidates: list | None = None, *, limit: int = 5) -> str:
+    """후보가 여럿이라 **고르지 않았을 때**의 안내 — 「못 찾았다」와 다른 사건이다.
+
+    못 찾은 것(ERROR)에 사명 변경 안내를 주는 것과 달리, 여기서는 회사가 **있고 여럿**이다.
+    그래서 필요한 것은 탈출구가 아니라 **후보 목록**인데, 종전엔 이 분기가 대부분 죽어 있어
+    (가드가 `ERROR or not selected` 인데 AMBIGUOUS 는 항상 selected 가 None 이라 앞에서 잡힌다)
+    후보를 손에 쥐고도 버리고 「찾지 못했다」로 답했다.
+    """
+    named = []
+    for c in (candidates or [])[:limit]:
+        if not isinstance(c, dict):
+            continue
+        nm = c.get("corp_name") or c.get("name") or ""
+        code = c.get("stock_code") or c.get("corp_code") or ""
+        named.append(f"{nm}({code})" if code else nm)
+    rest = max(0, len(candidates or []) - limit)
+    head = (f"'{query}'는 후보가 여럿이라 자동 선택하지 않았다"
+            + (f" — {' · '.join(named)}" + (f" 외 {rest}건" if rest else "") if named else ""))
+    return head + ". 종목코드 6자리나 corp_code 로 다시 조회한다."
+
+
 async def resolve_company_query(query: str) -> CompanyResolution:
     """회사 입력을 exact/ambiguous/error 상태로 정규화.
 

--- a/open_proxy_mcp/services/director_board.py
+++ b/open_proxy_mcp/services/director_board.py
@@ -43,7 +43,10 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 from open_proxy_mcp.dart.client import DartClientError, get_dart_client
-from open_proxy_mcp.services.company import resolve_company_query
+from open_proxy_mcp.services.company import (COMPANY_LOOKUP_NEXT_ACTION,
+                                             company_ambiguous_warning,
+                                             company_not_found_warning,
+                                             resolve_company_query)
 from open_proxy_mcp.services.executive_pay import parse_executive_pay, reconcile_with_api
 from open_proxy_mcp.services.shareholder_meeting_parser import is_outside_role
 from open_proxy_mcp.services.contracts import (
@@ -1160,16 +1163,20 @@ async def build_director_board_payload(
         ).to_dict()
 
     resolution = await resolve_company_query(company_query)
-    if resolution.status == AnalysisStatus.ERROR or not resolution.selected:
-        return ToolEnvelope(
-            tool="director_board", status=resolution.status, subject=company_query,
-            warnings=[f"'{company_query}' 상장사를 찾지 못함"],
-            data={"query": company_query, "candidates": resolution.candidates},
-        ).to_dict()
+    # AMBIGUOUS 가 먼저다 — 아래 가드의 `not selected` 가 그것까지 삼켜 이 분기가 죽어 있었다.
     if resolution.status == AnalysisStatus.AMBIGUOUS:
         return ToolEnvelope(
             tool="director_board", status=AnalysisStatus.AMBIGUOUS, subject=company_query,
+            warnings=[company_ambiguous_warning(company_query, resolution.candidates)],
             data={"query": company_query, "candidates": resolution.candidates},
+            next_actions=[COMPANY_LOOKUP_NEXT_ACTION],
+        ).to_dict()
+    if resolution.status == AnalysisStatus.ERROR or not resolution.selected:
+        return ToolEnvelope(
+            tool="director_board", status=resolution.status, subject=company_query,
+            warnings=[company_not_found_warning(company_query, listed_only=True)],
+            data={"query": company_query, "candidates": resolution.candidates},
+            next_actions=[COMPANY_LOOKUP_NEXT_ACTION],
         ).to_dict()
 
     selected = resolution.selected

--- a/open_proxy_mcp/services/forward_estimates.py
+++ b/open_proxy_mcp/services/forward_estimates.py
@@ -528,6 +528,8 @@ async def build_forward_estimates_payload(
 ) -> dict[str, Any]:
     """`fwd` 스냅샷 한 종목. status: ok / no_estimates / not_found / unlisted /
     ambiguous / db_error / invalid — **「없음」을 뭉뚱그리지 않는다.**"""
+    from open_proxy_mcp.services.company import (COMPANY_LOOKUP_NEXT_ACTION,
+                                             company_not_found_warning)
     from open_proxy_mcp.services.price_multiple_data import _resolve_listed
 
     query = (company or "").strip()
@@ -545,11 +547,15 @@ async def build_forward_estimates_payload(
     if early:
         early["tool"] = TOOL
         return early
-    if not corp or not corp.get("stock_code"):
-        return {"tool": TOOL, "status": "not_found" if not corp else "unlisted",
-                "subject": query,
-                "warnings": [f"'{query}' 상장 종목을 찾지 못함 — 회사명 오탈자이거나 비상장. "
-                             "우선주는 보통주 코드로 조회하세요. 회사 식별은 `company` 도구."]}
+    # 회사 자체가 없는 것과, 회사는 있는데 비상장인 것은 다른 사건이다.
+    if not corp:
+        return {"tool": TOOL, "status": "not_found", "subject": query,
+                "next_actions": [COMPANY_LOOKUP_NEXT_ACTION],
+                "warnings": [company_not_found_warning(query, listed_only=True),
+                             "우선주는 보통주 종목코드로 조회한다."]}
+    if not corp.get("stock_code"):
+        return {"tool": TOOL, "status": "unlisted", "subject": query,
+                "warnings": [f"'{query}' 는 찾았으나 상장 종목이 아니다 — 컨센서스는 상장사만 있다."]}
     isu = corp["stock_code"]
     subject = corp.get("corp_name", query)
 

--- a/open_proxy_mcp/services/order_contracts.py
+++ b/open_proxy_mcp/services/order_contracts.py
@@ -22,7 +22,10 @@ import re
 from typing import Any
 
 from open_proxy_mcp.dart.client import DartClientError, get_dart_client
-from open_proxy_mcp.services.company import resolve_company_query
+from open_proxy_mcp.services.company import (COMPANY_LOOKUP_NEXT_ACTION,
+                                             company_ambiguous_warning,
+                                             company_not_found_warning,
+                                             resolve_company_query)
 from open_proxy_mcp.services.contracts import (
     AnalysisStatus,
     EvidenceRef,
@@ -400,11 +403,21 @@ async def build_order_contracts_payload(
     client = get_dart_client()
     calls_start = client.api_call_snapshot()
     resolution = await resolve_company_query(company_query)
+    _cands = [_c for _c in (resolution.candidates or [])][:10]
+    # 후보가 여럿인 것(AMBIGUOUS)과 아예 없는 것(ERROR)은 다른 사건이다 — 종전엔 한 문장으로 뭉쳤다.
+    if resolution.status == AnalysisStatus.AMBIGUOUS:
+        return ToolEnvelope(
+            tool="order_contracts", status=AnalysisStatus.AMBIGUOUS, subject=company_query,
+            warnings=[company_ambiguous_warning(company_query, resolution.candidates)],
+            data={"query": company_query, "candidates": _cands},
+            next_actions=[COMPANY_LOOKUP_NEXT_ACTION],
+        ).to_dict()
     if resolution.status == AnalysisStatus.ERROR or not resolution.selected:
         return ToolEnvelope(
             tool="order_contracts", status=resolution.status,
-            subject=company_query, warnings=["회사를 특정하지 못했다."],
-            data={"query": company_query, "candidates": [_c for _c in (resolution.candidates or [])][:10]},
+            subject=company_query, warnings=[company_not_found_warning(company_query)],
+            data={"query": company_query, "candidates": _cands},
+            next_actions=[COMPANY_LOOKUP_NEXT_ACTION],
         ).to_dict()
 
     selected = resolution.selected

--- a/open_proxy_mcp/services/price_multiple_data.py
+++ b/open_proxy_mcp/services/price_multiple_data.py
@@ -22,7 +22,10 @@ import calendar
 
 from open_proxy_mcp.dart.client import get_dart_client, DartClientError, LruByteCache, _env_mb
 from open_proxy_mcp.dart.fx import fx_to_krw, statement_currency
-from open_proxy_mcp.services.company import _company_id, resolve_company_query
+from open_proxy_mcp.services.company import (COMPANY_LOOKUP_NEXT_ACTION,
+                                             company_ambiguous_warning,
+                                             company_not_found_warning,
+                                             _company_id, resolve_company_query)
 from open_proxy_mcp.services.contracts import AnalysisStatus
 from open_proxy_mcp.services.contracts import declare_weak_resolution
 from open_proxy_mcp.services.financial_metrics import build_financial_metrics_payload
@@ -464,7 +467,8 @@ async def build_sector_val_payload(company: str = "", format: str = "md",
         isu = (corp or {}).get("stock_code")
         if not isu:  # 회사 미해결/비상장 — 전체 표 덤프 대신 짧은 에러(실사용 QA P1: 1,600토큰 낭비 방지)
             return {"tool": "price_multiple_data", "status": "not_found", "subject": company,
-                    "warnings": [f"'{company}' 상장사를 찾지 못함 — 정확한 회사명/종목코드로 재시도. "
+                    "next_actions": [COMPANY_LOOKUP_NEXT_ACTION],
+                    "warnings": [company_not_found_warning(company, listed_only=True),
                                  "전체 섹터 표는 company 없이 scope='sector'."]}
         else:
             fr = await asyncio.to_thread(_pg_rows,
@@ -752,8 +756,14 @@ async def build_firm_history_payload(company: str, format: str = "md") -> dict[s
     if not corp:
         corp = await get_dart_client().lookup_corp_code(query)
     if not corp or not corp.get("stock_code"):
-        return {"tool": "price_multiple_data", "status": "not_found" if not corp else "unlisted",
-                "subject": query, "warnings": [f"'{company}' 상장 종목을 찾지 못함."]}
+        # 회사 자체가 없는 것과, 회사는 있는데 비상장인 것은 다른 사건이다 —
+        # 후자에 사명 변경 안내를 주면 사용자를 엉뚱한 쪽으로 끌고 간다.
+        if not corp:
+            return {"tool": "price_multiple_data", "status": "not_found", "subject": query,
+                    "next_actions": [COMPANY_LOOKUP_NEXT_ACTION],
+                    "warnings": [company_not_found_warning(company, listed_only=True)]}
+        return {"tool": "price_multiple_data", "status": "unlisted", "subject": query,
+                "warnings": [f"'{company}' 는 찾았으나 상장 종목이 아니다 — 배수는 주가가 있어야 낸다."]}
     isu = corp["stock_code"]
     cur_row = await asyncio.to_thread(_pg_rows,
         "SELECT market, induty, currency FROM dart_fundamentals WHERE ticker=%s", (isu,))
@@ -988,8 +998,9 @@ async def _build_valuation_payload_impl(company: str, format: str = "md") -> dic
         corp = await client.lookup_corp_code(query)
     if not corp:
         return {"tool": "price_multiple_data", "status": "not_found", "subject": company,
-                "warnings": [f"'{company}' 조회 결과 없음 — 종목코드(6자리)나 정확한 회사명으로 재시도. "
-                             "(우선주는 보통주 종목코드로 조회)"]}
+                "next_actions": [COMPANY_LOOKUP_NEXT_ACTION],
+                "warnings": [company_not_found_warning(company, listed_only=True),
+                             "우선주는 보통주 종목코드로 조회한다."]}
     cc, stock_code = corp["corp_code"], corp.get("stock_code")
     name = corp.get("corp_name", company)
     # 비상장 = 주가 없음 → 시장배수(PER·PBR) 정의 불가. DART 마스터엔 비상장 법인(삼성·쿠팡 등)도

--- a/open_proxy_mcp/services/provisional_earnings.py
+++ b/open_proxy_mcp/services/provisional_earnings.py
@@ -18,7 +18,10 @@ from typing import Any
 
 from bs4 import BeautifulSoup
 
-from open_proxy_mcp.services.company import resolve_company_query
+from open_proxy_mcp.services.company import (COMPANY_LOOKUP_NEXT_ACTION,
+                                             company_ambiguous_warning,
+                                             company_not_found_warning,
+                                             resolve_company_query)
 from open_proxy_mcp.services.contracts import AnalysisStatus, ToolEnvelope
 from open_proxy_mcp.services.segment_candidates import _table_to_grid
 from open_proxy_mcp.services.fiscal_period import period_from_quarter_text, period_metadata
@@ -363,11 +366,18 @@ async def build_provisional_earnings_payload(
     from open_proxy_mcp.dart.client import get_dart_client, DartClientError
     res = await resolve_company_query(company_query)
     if not res.selected:
-        return ToolEnvelope(tool="provisional_earnings", status=AnalysisStatus.AMBIGUOUS
-                            if res.candidates else AnalysisStatus.ERROR,
-                            subject=company_query,
-                            data={"candidates": [c.get("corp_name") for c in (res.candidates or [])][:8]},
-                            warnings=["회사 식별 실패"]).to_dict()
+        # 판별자는 candidates 유무가 아니라 **status** 다 — ERROR 도 근접 후보를 실어 오므로
+        # candidates 로 가르면 「못 찾음」이 「모호」로 오분류된다.
+        _amb = res.status == AnalysisStatus.AMBIGUOUS
+        return ToolEnvelope(
+            tool="provisional_earnings",
+            status=AnalysisStatus.AMBIGUOUS if _amb else AnalysisStatus.ERROR,
+            subject=company_query,
+            data={"query": company_query,
+                  "candidates": [c.get("corp_name") for c in (res.candidates or [])][:8]},
+            warnings=[company_ambiguous_warning(company_query, res.candidates) if _amb
+                      else company_not_found_warning(company_query)],
+            next_actions=[COMPANY_LOOKUP_NEXT_ACTION]).to_dict()
     corp = res.selected
     client = get_dart_client()
     bgn_de = start_date or (today_kst() - timedelta(days=months * 31)).strftime("%Y%m%d")

--- a/open_proxy_mcp/services/proxy_advise.py
+++ b/open_proxy_mcp/services/proxy_advise.py
@@ -38,7 +38,10 @@ from open_proxy_mcp.services.provisional_financial_statement import (
     parse_provisional_financial_statement,
     extract_metrics as _extract_provisional_fs_metrics,
 )
-from open_proxy_mcp.services.company import _company_id, resolve_company_query
+from open_proxy_mcp.services.company import (COMPANY_LOOKUP_NEXT_ACTION,
+                                             company_ambiguous_warning,
+                                             company_not_found_warning,
+                                             _company_id, resolve_company_query)
 from open_proxy_mcp.services.contracts import (
     AnalysisStatus,
     EvidenceRef,
@@ -3546,35 +3549,39 @@ async def _build_proxy_advise_payload(
     stage_started_at = time.perf_counter()
     resolution = await resolve_company_query(company_query)
     _mark("resolve_company", stage_started_at)
-    if resolution.status == AnalysisStatus.ERROR or not resolution.selected:
-        timings_ms["total"] = int((time.perf_counter() - total_started_at) * 1000)
-        return ToolEnvelope(
-            tool="proxy_advise_before_meeting",
-            status=AnalysisStatus.ERROR,
-            subject=company_query,
-            warnings=[f"'{company_query}' 회사 식별 실패"],
-            data={
-                "query": company_query,
-                "usage": build_usage(client.api_call_snapshot() - calls_start),
-                "timings_ms": timings_ms,
-            },
-        ).to_dict()
+    # AMBIGUOUS 를 먼저 — 아래 가드의 `not selected` 가 그것까지 삼켜 이 분기가 죽어 있었다.
     if resolution.status == AnalysisStatus.AMBIGUOUS:
         timings_ms["total"] = int((time.perf_counter() - total_started_at) * 1000)
         return ToolEnvelope(
             tool="proxy_advise_before_meeting",
             status=AnalysisStatus.AMBIGUOUS,
             subject=company_query,
-            warnings=["회사 식별 모호"],
+            warnings=[company_ambiguous_warning(company_query, resolution.candidates)],
             data={
                 "query": company_query,
                 "candidates": [
-                    {"corp_name": c.get("corp_name"), "corp_code": c.get("corp_code")}
+                    {"corp_name": c.get("corp_name"), "corp_code": c.get("corp_code"),
+                     "stock_code": c.get("stock_code")}
                     for c in resolution.candidates[:10]
                 ],
                 "usage": build_usage(client.api_call_snapshot() - calls_start),
                 "timings_ms": timings_ms,
             },
+            next_actions=[COMPANY_LOOKUP_NEXT_ACTION],
+        ).to_dict()
+    if resolution.status == AnalysisStatus.ERROR or not resolution.selected:
+        timings_ms["total"] = int((time.perf_counter() - total_started_at) * 1000)
+        return ToolEnvelope(
+            tool="proxy_advise_before_meeting",
+            status=AnalysisStatus.ERROR,
+            subject=company_query,
+            warnings=[company_not_found_warning(company_query)],
+            data={
+                "query": company_query,
+                "usage": build_usage(client.api_call_snapshot() - calls_start),
+                "timings_ms": timings_ms,
+            },
+            next_actions=[COMPANY_LOOKUP_NEXT_ACTION],
         ).to_dict()
 
     selected = resolution.selected

--- a/open_proxy_mcp/services/screener.py
+++ b/open_proxy_mcp/services/screener.py
@@ -19,7 +19,7 @@ from open_proxy_mcp.dart.client import LruByteCache, _env_mb, list_pages_per_cod
 from open_proxy_mcp.db import pg_rows
 from open_proxy_mcp.market_codes import KS as MKT_KS, KQ as MKT_KQ, to_db
 
-from open_proxy_mcp.services.contracts import declare_weak_resolution
+from open_proxy_mcp.services.contracts import declare_weak_resolution, AnalysisStatus
 
 import asyncio
 import math
@@ -30,7 +30,7 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Any, Callable, Iterable
 
 from open_proxy_mcp.dart.client import DartClientError, get_dart_client
-from open_proxy_mcp.services.company import resolve_company_query
+from open_proxy_mcp.services.company import resolve_company_query, company_ambiguous_warning, company_not_found_warning
 
 # ── KST(공시 기준 시간대) ──────────────────────────────────────────────
 _KST = timezone(timedelta(hours=9))
@@ -609,21 +609,29 @@ async def _resolve_custom_universe(raw: str, price_dd: str | None) -> UniverseFi
         else:
             name_tokens.append(tok)
 
-    async def _resolve_one(tok: str) -> tuple[str, str | None]:
-        # 이름/티커 → 회사 식별(기존 엔진 재사용, 이름당 DART 0콜=캐시)
+    async def _resolve_one(tok: str) -> tuple[str, str | None, str]:
+        """(토큰, 종목코드, 안내) — 못 찾은 이유를 **토큰마다** 말한다.
+
+        종전엔 「'X' 미식별(모호/없음)」 한 문장이라, 사명이 바뀐 회사인지 후보가 여럿인지
+        구분할 수 없었다. 다른 tool 은 정본 안내를 주는데 여기만 안 줬다.
+        """
         try:
             res = await resolve_company_query(tok)
         except Exception:
-            return tok, None
+            return tok, None, f"'{tok}' 조회 중 오류 — 종목코드 6자리로 다시 준다."
         sel = getattr(res, "selected", None)
-        return tok, ((sel or {}).get("stock_code") if sel else None)
+        if sel:
+            return tok, (sel or {}).get("stock_code"), ""
+        if getattr(res, "status", None) == AnalysisStatus.AMBIGUOUS:
+            return tok, None, company_ambiguous_warning(tok, getattr(res, "candidates", None))
+        return tok, None, company_not_found_warning(tok)
 
     if name_tokens:
-        for tok, sc in await asyncio.gather(*[_resolve_one(t) for t in name_tokens]):
+        for tok, sc, hint in await asyncio.gather(*[_resolve_one(t) for t in name_tokens]):
             if sc:
                 codes.add(sc.strip())
             else:
-                notes.append(f"'{tok}' 미식별(모호/없음)")
+                notes.append(hint or f"'{tok}' 미식별(모호/없음)")
     if not codes:
         notice = ("일부 종목 미해결: " + " · ".join(notes)) if notes else ""
         return UniverseFilter(label="지정종목", resolved=False,

--- a/open_proxy_mcp/services/shareholder_commitment.py
+++ b/open_proxy_mcp/services/shareholder_commitment.py
@@ -33,7 +33,10 @@ import asyncio
 from typing import Any
 
 from open_proxy_mcp.dart.client import get_dart_client
-from open_proxy_mcp.services.company import resolve_company_query
+from open_proxy_mcp.services.company import (COMPANY_LOOKUP_NEXT_ACTION,
+                                             company_ambiguous_warning,
+                                             company_not_found_warning,
+                                             resolve_company_query)
 from open_proxy_mcp.services.contracts import (
     AnalysisStatus,
     ToolEnvelope,
@@ -198,20 +201,23 @@ async def build_shareholder_commitment_payload(
 ) -> dict[str, Any]:
     calls_start = get_dart_client().api_call_snapshot()
     resolution = await resolve_company_query(company_query)
-    if resolution.status == AnalysisStatus.ERROR or not resolution.selected:
-        return ToolEnvelope(
-            tool="shareholder_commitment",
-            status=resolution.status,
-            subject=company_query,
-            warnings=[f"'{company_query}' 상장사를 찾지 못함"],
-            data={"query": company_query, "candidates": resolution.candidates},
-        ).to_dict()
     if resolution.status == AnalysisStatus.AMBIGUOUS:
         return ToolEnvelope(
             tool="shareholder_commitment",
             status=AnalysisStatus.AMBIGUOUS,
             subject=company_query,
+            warnings=[company_ambiguous_warning(company_query, resolution.candidates)],
             data={"query": company_query, "candidates": resolution.candidates},
+            next_actions=[COMPANY_LOOKUP_NEXT_ACTION],
+        ).to_dict()
+    if resolution.status == AnalysisStatus.ERROR or not resolution.selected:
+        return ToolEnvelope(
+            tool="shareholder_commitment",
+            status=resolution.status,
+            subject=company_query,
+            warnings=[company_not_found_warning(company_query, listed_only=True)],
+            data={"query": company_query, "candidates": resolution.candidates},
+            next_actions=[COMPANY_LOOKUP_NEXT_ACTION],
         ).to_dict()
 
     selected = resolution.selected

--- a/open_proxy_mcp/tools/business_details.py
+++ b/open_proxy_mcp/tools/business_details.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 
+from open_proxy_mcp.services.company import company_not_found_warning
 from open_proxy_mcp.services.business_details import build_business_details_payload
 from open_proxy_mcp.services.contracts import as_pretty_json
 
@@ -289,7 +290,10 @@ def _render(p: dict) -> str:
     d = p.get("data", {}) or {}
     subj = p.get("subject", "")
     if status in ("error", "ambiguous"):
-        return f"**{subj}** — {'; '.join(p.get('warnings') or ['회사 식별 실패'])}"
+        # 서비스가 항상 안내를 싣는다(company_not_found_warning / company_ambiguous_warning).
+        # 그래도 비면 **정본을 다시 만든다** — 여기서 문구를 지어내면 그게 또 사본이 된다.
+        _ws = p.get("warnings") or [company_not_found_warning(str(subj))]
+        return f"**{subj}** — {'; '.join(_ws)}"
     if status == "no_filing":
         return f"**{subj}** — {'; '.join(p.get('warnings') or ['정기보고서 없음'])}"
     L = []

--- a/open_proxy_mcp/tools/financial_notes.py
+++ b/open_proxy_mcp/tools/financial_notes.py
@@ -12,7 +12,7 @@ from open_proxy_mcp.services import financial_notes as svc
 from open_proxy_mcp.services.business_details import (
     _find_report_candidates, _find_report_for_bsns_year, _report_period_tag,
 )
-from open_proxy_mcp.services.company import resolve_company_query
+from open_proxy_mcp.services.company import resolve_company_query, company_ambiguous_warning, company_not_found_warning, COMPANY_LOOKUP_NEXT_ACTION
 from open_proxy_mcp.services.contracts import AnalysisStatus
 from open_proxy_mcp.services.contracts import ToolEnvelope
 
@@ -549,9 +549,13 @@ def register_tools(mcp):
 
         resolution = await resolve_company_query(company)
         if resolution.status != AnalysisStatus.EXACT or not resolution.selected:
-            env = ToolEnvelope(tool="financial_notes", status=resolution.status,
-                               subject=company, warnings=["회사를 하나로 식별하지 못했습니다"],
-                               data={"candidates": resolution.candidates})
+            _amb = resolution.status == AnalysisStatus.AMBIGUOUS
+            env = ToolEnvelope(
+                tool="financial_notes", status=resolution.status, subject=company,
+                warnings=[company_ambiguous_warning(company, resolution.candidates) if _amb
+                          else company_not_found_warning(company)],
+                data={"query": company, "candidates": resolution.candidates},
+                next_actions=[COMPANY_LOOKUP_NEXT_ACTION])
             return json.dumps(env.to_dict(), ensure_ascii=False)
         corp = resolution.selected
         corp_code = corp["corp_code"]

--- a/tests/output_vocab_baseline.json
+++ b/tests/output_vocab_baseline.json
@@ -10,7 +10,7 @@
   "services/dividend_data.py": 3,
   "services/financial_metrics.py": 2,
   "services/ownership_structure.py": 1,
-  "services/price_multiple_data.py": 4,
+  "services/price_multiple_data.py": 3,
   "services/proxy_contest.py": 1,
   "services/risk_events.py": 1,
   "services/screener.py": 2,

--- a/tests/test_company_not_found_hint.py
+++ b/tests/test_company_not_found_hint.py
@@ -32,6 +32,15 @@ def test_the_listed_only_wording_stays_available() -> None:
     assert "회사를 찾지 못했다" in company_not_found_warning("없는회사")
 
 
+#: 손으로 지어 쓰던 미해결 문구들. 260909 에 열 개 파일에서 걷어냈다 — 다시 들어오면 여기서 걸린다.
+#: (커버리지는 `test_not_found_hint_coverage.py` 가 따로 본다 — 이 목록은 **문구 복제**만 막는다.)
+_BANNED = (
+    "해당하는 회사를 찾지 못했다", "해당하는 상장사를 찾지 못했다",
+    "회사 식별 실패", "회사를 특정하지 못했다", "상장사를 찾지 못함",
+    "상장 종목을 찾지 못함", "회사를 하나로 식별하지 못",
+)
+
+
 def test_nobody_hardcodes_the_message_anymore() -> None:
     """같은 문구가 14곳에 흩어져 있었다 — 다음에 또 14곳을 고치는 일이 없도록 고정한다."""
     offenders = []
@@ -40,6 +49,6 @@ def test_nobody_hardcodes_the_message_anymore() -> None:
             continue
         for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
             if isinstance(node, ast.Constant) and isinstance(node.value, str):
-                if "해당하는 회사를 찾지 못했다" in node.value or "해당하는 상장사를 찾지 못했다" in node.value:
-                    offenders.append(f"{path.name}:{node.lineno}")
-    assert not offenders, f"company_not_found_warning() 을 쓸 것: {offenders}"
+                if any(bad in node.value for bad in _BANNED):
+                    offenders.append(f"{path.name}:{node.lineno} — {node.value[:40]}")
+    assert not offenders, f"company_not_found_warning()/company_ambiguous_warning() 을 쓸 것: {offenders}"

--- a/tests/test_not_found_hint_coverage.py
+++ b/tests/test_not_found_hint_coverage.py
@@ -1,0 +1,90 @@
+"""회사를 못 찾았을 때의 안내가 **모든 진입점에서 같은지** — AST 스캔, 네트워크 0.
+
+기존 `tests/test_company_not_found_hint.py` 는 **문구 복제**만 막는다(같은 리터럴 금지).
+그래서 「헬퍼를 아예 안 부르는」 파일은 리터럴이 다르니 통과했다 — 260909 조사에서
+`resolve_company_query` 를 쓰는 25개 중 **11개가 그렇게 통과하고 있었다.**
+
+증상: 같은 회사를 두 tool 로 물으면 한쪽만 「사명이 바뀌었다 → 케이젯정밀(036560)」을 준다.
+사명 변경은 하필 지배구조 분쟁 직후에 잦아 의결권 분석이 가장 필요한 국면과 겹친다.
+
+그래서 문구가 아니라 **호출**을 센다.
+"""
+import ast
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent / "open_proxy_mcp"
+HELPERS = {"company_not_found_warning", "company_ambiguous_warning"}
+
+#: 회사를 해석하지만 not-found 안내를 만들 자리가 아닌 곳. **줄이는 방향으로만** 바뀐다.
+#: 여기 넣을 때는 왜 아닌지를 한 줄로 적는다 — 나중 사람이 판단을 되짚을 수 있게.
+EXEMPT = {
+    "services/company.py": "정본이 사는 곳",
+    "services/director_evaluation.py": "후보 평가 chain — 회사는 상위에서 이미 확정된다",
+    "tools/__init__.py": "docstring 안 설명 문구일 뿐 호출부가 아니다",
+}
+
+
+def _modules():
+    for p in sorted(ROOT.rglob("*.py")):
+        rel = p.relative_to(ROOT).as_posix()
+        try:
+            yield rel, p, ast.parse(p.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover
+            continue
+
+
+def _calls(tree) -> set[str]:
+    out = set()
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Call):
+            f = n.func
+            if isinstance(f, ast.Name):
+                out.add(f.id)
+            elif isinstance(f, ast.Attribute):
+                out.add(f.attr)
+    return out
+
+
+def test_every_company_resolving_module_uses_the_canonical_hint():
+    """`resolve_company_query` 를 부르면 못 찾았을 때의 안내도 정본으로 준다."""
+    bad = []
+    for rel, _p, tree in _modules():
+        calls = _calls(tree)
+        if "resolve_company_query" not in calls or rel in EXEMPT:
+            continue
+        if not (calls & HELPERS):
+            bad.append(rel)
+    assert not bad, (
+        "회사를 해석하면서 못 찾았을 때의 안내를 정본으로 안 준다 — "
+        f"{bad}. `company_not_found_warning`(없음) / `company_ambiguous_warning`(모호) 를 쓴다."
+    )
+
+
+def test_exemptions_are_real_modules():
+    """면제 목록이 낡으면 이 테스트가 조용히 헐거워진다."""
+    missing = [rel for rel in EXEMPT if not (ROOT / rel).exists()]
+    assert not missing, f"면제 목록에 없는 파일이 있다: {missing}"
+
+    for rel in EXEMPT:
+        tree = ast.parse((ROOT / rel).read_text(encoding="utf-8"))
+        if rel == "tools/__init__.py":
+            assert "resolve_company_query" not in _calls(tree), \
+                "tools/__init__.py 가 실제로 회사를 해석하기 시작했다 — 면제를 거둬야 한다"
+
+
+def test_ambiguous_hint_lists_the_candidates_it_has():
+    """모호할 때 필요한 것은 탈출구가 아니라 **후보**다 — 손에 쥐고도 버리면 안 된다."""
+    from open_proxy_mcp.services.company import company_ambiguous_warning
+
+    msg = company_ambiguous_warning("금호", [
+        {"corp_name": "금호타이어", "stock_code": "073240"},
+        {"corp_name": "금호석유화학", "stock_code": "011780"},
+    ])
+    assert "금호타이어" in msg and "073240" in msg
+    assert "금호석유화학" in msg
+
+    many = company_ambiguous_warning("가", [{"corp_name": f"A{i}", "stock_code": f"{i:06d}"}
+                                            for i in range(9)], limit=3)
+    assert "외 6건" in many, "상한을 넘긴 후보 수를 밝힌다"
+
+    assert "후보가 여럿" in company_ambiguous_warning("가", [])   # 후보가 비어도 뜻은 남는다

--- a/wiki/decisions/후보반환-설계.md
+++ b/wiki/decisions/후보반환-설계.md
@@ -44,3 +44,27 @@ truth 를 에이전트 추출로 실증) 그쪽에 넘기는 편이 더 정확�
 
 - [[BeautifulSoup-파서-선택]]
 - 검증 기준은 memory `feedback-measurement-trust`(표본·회귀·오탐 QA)
+
+## 회사 미해결 안내의 정본 (260909)
+
+「못 찾았다」와 「고르지 못했다」는 **다른 사건**이고 사용자에게 필요한 것도 다르다.
+
+| | 정본 | 사용자에게 필요한 것 |
+|---|---|---|
+| ERROR (후보 0) | `company_not_found_warning(query, listed_only=)` | 사명이 바뀌었는지, 아니면 **종목코드 탈출구** |
+| AMBIGUOUS (후보 여럿) | `company_ambiguous_warning(query, candidates)` | 탈출구가 아니라 **후보 목록** |
+
+- **판별자는 `candidates` 유무가 아니라 `status` 다.** ERROR 도 근접 후보를 실어 오므로
+  candidates 로 가르면 「못 찾음」이 「모호」로 오분류된다.
+- **가드 순서는 AMBIGUOUS 가 먼저다.** AMBIGUOUS 는 항상 `selected` 가 None 이라
+  `if status == ERROR or not selected:` 가 먼저 오면 그 분기를 통째로 삼킨다 —
+  실제로 여러 tool 에서 AMBIGUOUS 분기가 도달 불가로 죽어 있었고, 후보를 손에 쥐고도 버렸다.
+- **봉투는 통일하지 않는다.** 반환 계약이 4종(ToolEnvelope · 문자열 status dict · JSON 문자열 ·
+  dataclass note)인데 이유가 각각 있다. 결함은 봉투가 아니라 **문장**이었다 —
+  공용 봉투 함수는 그 이유들을 못 삼키면서 25개 파일을 건드린다.
+- 회사는 찾았는데 **그 tool 의 데이터가 없는** 경우(NO_FILING·비상장·원문 수급 실패)에
+  not-found 안내를 쓰면 사용자를 사명 변경 쪽으로 잘못 끌고 간다. 그건 다른 문장이다.
+
+회귀는 두 겹이다 — `test_company_not_found_hint.py`(문구 복제 금지)와
+`test_not_found_hint_coverage.py`(**호출 커버리지** AST 스캔). 전자만으로는 「헬퍼를 아예 안 부르는」
+파일이 리터럴이 달라 통과한다 — 실제로 11개가 그렇게 통과하고 있었다.


### PR DESCRIPTION
`resolve_company_query` 를 쓰는 25개 파일 중 **11개가 정본 헬퍼를 안 불렀습니다.**

같은 회사를 두 tool 로 물으면 한쪽만 「사명이 바뀌었다 → 케이젯정밀(036560)」을 주고, 다른 쪽은
「회사 식별 실패」 다섯 글자로 끝났습니다. 사명 변경은 하필 **지배구조 분쟁 직후에 잦아** 의결권
분석이 가장 필요한 국면과 겹칩니다.

## 봉투가 아니라 문장을 통일합니다

조사에서 판단이 갈렸는데, **공용 봉투 함수는 만들지 않기로** 했습니다.

반환 계약이 4종입니다 — `ToolEnvelope` · 문자열 status 생 dict · JSON 문자열 · dataclass note.
그리고 각각 이유가 있습니다. 사용자가 잃은 것은 「어디로 갔는지」와 「종목코드 탈출구」이고 그건
`company_not_found_warning()` 이 돌려주는 **str 하나**입니다. 봉투가 달라서 힌트가 사라진 게 아니라
**그 str 을 안 불러서** 사라졌습니다. 공용 봉투는 그 이유들을 못 삼키면서 25개 파일을 건드립니다.

## AMBIGUOUS 분기가 죽어 있었습니다

```python
if resolution.status == AnalysisStatus.ERROR or not resolution.selected:   # ← 여기서 다 잡힌다
    ...
if resolution.status == AnalysisStatus.AMBIGUOUS:                          # ← 도달 불가
    ...
```

**AMBIGUOUS 는 항상 `selected` 가 None** 이라 위 가드가 통째로 삼킵니다. `director_board` ·
`shareholder_commitment` · `proxy_advise` 에서 실제로 죽은 코드였고, **후보를 손에 쥐고도 버리고**
「찾지 못했다」로 답해 왔습니다. 순서를 뒤집고 `company_ambiguous_warning(query, candidates)` 를
신설했습니다 — 모호할 때 필요한 건 탈출구가 아니라 **후보 목록**입니다.

판별자도 고쳤습니다: `candidates` 유무가 아니라 **status** 입니다. ERROR 도 근접 후보를 실어
오므로 candidates 로 가르면 「못 찾음」이 「모호」로 오분류됩니다(`provisional_earnings` 가 그랬습니다).

## 건드리지 않은 것

회사는 **찾았는데** 그 tool 의 데이터가 없는 경우(NO_FILING · 비상장 · 원문 수급 실패 · 파라미터
오류)는 다른 사건입니다. 여기에 not-found 안내를 넣으면 사용자를 사명 변경 쪽으로 잘못 끌고 갑니다.
조사에서 그런 자리 20여 곳을 골라내 제외했고, 비상장 안내는 「찾았으나 상장이 아니다」로 분리했습니다.

## 회귀를 두 겹으로 — 그리고 그게 바로 값을 했습니다

기존 `test_company_not_found_hint.py` 는 **문구 복제**만 막아서, 「헬퍼를 아예 안 부르는」 파일은
리터럴이 달라 통과했습니다. 11개가 그렇게 통과하고 있었습니다.

그래서 `test_not_found_hint_coverage.py` 를 더했습니다 — AST 로 `resolve_company_query` 호출자를
찾아 헬퍼 호출이 있는지 봅니다(**22개 모듈 검사**, 헬퍼를 지우면 실제로 실패하는지 확인했습니다).

그리고 금지 문구 목록을 넓혔더니 **조사가 놓친 두 곳**이 걸렸습니다:
- `forward_estimates` — 공용 리졸버를 쓰지만 `resolve_company_query` 를 직접 안 불러 AST 스캔에 안 걸림
- `tools/business_details` 의 빈 warnings 폴백 — 문구를 지어내던 자리

## 검증 (MCP 호출)

| 질의 | 결과 |
|---|---|
| 존재하지 않는 이름 | 6개 tool 이 **같은 안내** |
| 사명 변경 질의 | 6개 tool 이 같은 안내 (＊) |
| `'엔에스'`(모호) | 5개 중 4개가 후보를 문장으로. `order_contracts` 는 렌더러가 `corp_code` 표를 그려 문장 대신 표를 준다 — payload 에는 있다 |

＊ 이번 표본(`영풍정밀`)에서 개명 안내 대신 일반 문구가 나오는데, 이건 결함이 아니라
`lookup_former_name` 이 스스로 적어 둔 한계입니다 — 「이력은 우리가 스냅샷을 남기기 시작한 뒤의
변경만 담는다. 그 전에 이미 바뀐 사명은 DART 어디에도 없어 복구할 수 없다」. 그 경우 종목코드
탈출구가 정답입니다.

`vocab lint` 래칫이 `price_multiple_data` 4→3 으로 **조여졌습니다**(엔진 용어가 줄었습니다).

`pytest` **1,712 통과**(신규 3) · `wiki_lint --strict` · `check_tool_catalog`(31).
`wiki/decisions/후보반환-설계.md` 에 판별 규칙·가드 순서·봉투를 통일하지 않는 이유를 기록했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)