### PR TITLE
OOM 이 나는 자리를 보이게 — 예산 없는 전역 캐시 + 런타임 카운터

### DIFF
--- a/open_proxy_mcp/dart/client.py
+++ b/open_proxy_mcp/dart/client.py
@@ -917,6 +917,66 @@ def cache_stats() -> dict:
     return out
 
 
+#: **예산 없는 전역 캐시 장부.** `_CACHE_REGISTRY` 는 `LruByteCache` 전용이라, 서비스가 모듈
+#: 전역에 둔 평범한 dict 캐시는 거기 안 들어간다 — 그리고 그런 캐시는 상한도 evict 도 없다.
+#:
+#: 왜 필요한가(260901·260909). 260901 에 두 머신이 동시에 OOM(exit 137) 했을 때 캐시 점유는
+#: 예산 296MB 의 33% 였고 실사용은 950MB 였다. 260909 에도 같은 모양이 났다 — 부팅 직후
+#: 242MB 인 프로세스가 30분 만에 708MB 가 되고 2~3시간마다 죽는데, `cache_stats()` 는
+#: 내내 `_used_mb: 0.0` 을 보고했다. **자라는 것이 우리가 보는 자리 밖에 있다.**
+#:
+#: 260824 교훈을 그대로 가져온다 — 나열하지 말고 장부로 돌린다. 등록하면 자동으로 보인다.
+_UNBUDGETED_CACHES: "list[tuple[str, Any]]" = []
+
+#: 바이트는 **표본 추정**이다(`_note_registry` 와 같은 이유). 값이 통짜 페이로드일 수 있어
+#: 전수 재귀는 헬스체크 한 번을 수백 ms 로 만든다. 그리고 그 계산 자체가 메모리를 흔든다 —
+#: 재는 행위가 재려는 대상을 바꾸면 안 된다.
+_UNBUDGETED_SAMPLE = 20
+_UNBUDGETED_TTL_SEC = 60.0
+_unbudgeted_memo: "dict[str, tuple[float, int, int]]" = {}
+
+
+def register_unbudgeted_cache(name: str, getter) -> None:
+    """예산 없는 모듈 전역 캐시를 관측 장부에 올린다.
+
+    `getter` 는 **호출 가능한 것**을 받는다 — dict 를 직접 받으면 `_X_CACHE = None` 으로
+    시작해 나중에 재바인딩되는 캐시에서 옛 객체를 붙들게 된다(그러면 영영 0 을 보고한다).
+    """
+    if not any(n == name for n, _ in _UNBUDGETED_CACHES):
+        _UNBUDGETED_CACHES.append((name, getter))
+
+
+def unbudgeted_cache_stats() -> dict:
+    """예산 없는 캐시들의 개수·대략 바이트. `/health` 가 노출한다.
+
+    항목 수는 매번 세고(싸다), 바이트는 60초에 한 번만 다시 잰다.
+    """
+    out: dict = {}
+    total = 0
+    now = time.time()
+    for name, getter in _UNBUDGETED_CACHES:
+        try:
+            obj = getter()
+        except Exception:                      # 관측이 서빙을 깨면 안 된다
+            continue
+        n = len(obj) if obj is not None else 0
+        memo = _unbudgeted_memo.get(name)
+        if memo and now - memo[0] < _UNBUDGETED_TTL_SEC and memo[1] == n:
+            est = memo[2]
+        else:
+            try:
+                vals = list(_islice(obj.values(), _UNBUDGETED_SAMPLE)) if isinstance(obj, dict) else []
+                avg = (sum(_cache_entry_bytes(v) for v in vals) / len(vals)) if vals else 0
+                est = int(avg * n)
+            except Exception:
+                est = 0
+            _unbudgeted_memo[name] = (now, n, est)
+        total += est
+        out[name] = {"entries": n, "bytes_est": est}
+    out["_total_mb"] = round(total / 1024 / 1024, 1)
+    return out
+
+
 def cache_clear(disk: bool = False) -> dict:
     """메모리 캐시를 **전부** 비운다. 반환 = 비우기 전후 대조.
 

--- a/open_proxy_mcp/server.py
+++ b/open_proxy_mcp/server.py
@@ -135,7 +135,7 @@ def build_mcp() -> MCPServer:
         from starlette.responses import JSONResponse
         from open_proxy_mcp.dart.client import (cache_stats, client_registry_stats,
                                         doc_gate_stats, inflight_now, registry_stats,
-                                        web_block_stats)
+                                        unbudgeted_cache_stats, web_block_stats)
         from open_proxy_mcp.db import pool_stats
         # 260814: 법령 데이터가 통째로 비어도 응답이 평소와 같은 모양이라 **밖에서 안 보였다** —
         #   룰 40개가 0이 되면 강행규정 판정이 전부 사라지는데 경고도 신호도 없었다.
@@ -156,6 +156,12 @@ def build_mcp() -> MCPServer:
             "tools": len(await mcp.list_tools()),
             "data": _data,
             "cache": cache_stats(),
+            # 260909: 예산 **없는** 전역 dict 캐시들. `cache` 가 0.0MB 를 보고하는 동안
+            #   프로세스는 30분에 466MB 가 늘었다 — 자라는 것이 관측 밖에 있다는 뜻이다.
+            #   상한 있는 `trading_quote` 를 대조군으로 같이 싣는다(그게 평평하면 판정이 선다).
+            "unbudgeted_cache": unbudgeted_cache_stats(),
+            # 260909: 캐시가 아닌 증가(태스크·스레드 누수, 회수 못 한 순환)를 가르는 자.
+            "runtime": _runtime_stats(),
             # 원장(회사 목록·정기보고서 명부) — 「언제 것이고 얼마나 무거운가」.
             # 메모리 층에는 만료가 없어서 fly 의 suspend/재개로 프로세스가 오래 살면 그만큼
             # 묵는다(sqlite TTL 7일은 메모리가 비었을 때만 걸린다). 신규 상장사를 「없다」고
@@ -458,6 +464,42 @@ def _mem_stats() -> dict:
             pass
     if out.get("cg_used_mb") and out.get("cg_limit_mb"):
         out["cg_pct"] = round(out["cg_used_mb"] / out["cg_limit_mb"] * 100, 1)
+    return out
+
+
+def _runtime_stats() -> dict:
+    """살아 있는 태스크·스레드·GC 세대 수. **캐시가 아닌 증가**를 가르려고 둔다.
+
+    260909: 부팅 직후 242MB 인 프로세스가 30분 만에 708MB 가 되는데 캐시 점유는 내내
+    0.0MB 였다. 자라는 게 캐시가 아니면 남는 후보는 (a) 예산 없는 전역 dict,
+    (b) 회수 안 되는 태스크·스레드, (c) 순환 참조로 GC 에 걸린 객체 셋이다.
+    (a) 는 `unbudgeted_cache`, (b)(c) 는 여기서 본다 — 셋을 같이 봐야 어느 쪽인지 갈린다.
+
+    `gc.get_objects()` 는 전수 순회라 안 쓴다(헬스체크가 그만큼 멈춘다).
+    `get_count()` 는 세대별 카운터라 공짜다.
+    """
+    out: dict = {}
+    try:
+        import asyncio
+        try:
+            out["tasks"] = len(asyncio.all_tasks())
+        except RuntimeError:          # 루프 밖에서 불렸다
+            pass
+    except Exception:
+        pass
+    try:
+        import threading
+        out["threads"] = threading.active_count()
+    except Exception:
+        pass
+    try:
+        import gc
+        out["gc_count"] = list(gc.get_count())
+        out["gc_collected"] = sum(st.get("collected", 0) for st in gc.get_stats())
+        out["gc_uncollectable"] = sum(st.get("uncollectable", 0) for st in gc.get_stats())
+        out["gc_garbage"] = len(gc.garbage)     # 0 이 아니면 회수 못 한 순환이 쌓인다
+    except Exception:
+        pass
     return out
 
 

--- a/open_proxy_mcp/services/financial_metrics.py
+++ b/open_proxy_mcp/services/financial_metrics.py
@@ -2523,8 +2523,14 @@ def _unsupported_scope_payload(company_query: str, scope: str) -> dict[str, Any]
 # 같은 (company, scope, year, consolidated) 조합 재호출 시 동일 결과 보장.
 # advise_vote의 3 run 호출 시 모든 run에서 동일 fm_payload 반환 → cash_dividend 결정 결정성.
 import time as _time_mod
+from open_proxy_mcp.dart.client import register_unbudgeted_cache as _register_unbudgeted_cache
 _FM_CACHE: dict[tuple, tuple[float, dict[str, Any]]] = {}
 _FM_CACHE_TTL = 300.0  # 5분
+
+# TTL 은 **읽을 때만** 걸린다(아래 `_fm_cache_get`) — 쓰고 다시 안 읽히는 키는 안 지워진다.
+# 값이 통짜 페이로드라 그 잔여가 얼마인지 밖에서 보이는 편이 낫다. 지금은 재는 중이고,
+# 자라는 게 확인되면 상한이나 sweep 을 단다(재기 전에 고르지 않는다).
+_register_unbudgeted_cache("financial_metrics", lambda: _FM_CACHE)
 
 
 def _fm_cache_get(key: tuple) -> dict[str, Any] | None:

--- a/open_proxy_mcp/services/law_lookup.py
+++ b/open_proxy_mcp/services/law_lookup.py
@@ -34,6 +34,8 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any, Iterable
 
+from open_proxy_mcp.dart.client import register_unbudgeted_cache as _register_unbudgeted_cache
+
 from open_proxy_mcp.services.contracts import (
     AnalysisStatus,
     EvidenceRef,
@@ -257,6 +259,12 @@ def expand_query_tokens(tokens: set[str], as_of_iso: str) -> set[str]:
 # ── corpus 인덱스 로더 (캐시) ───────────────────────────────────────────
 _INDEX_CACHE: dict[str, Any] | None = None
 _FULLTEXT_CACHE: dict[str, str] = {}
+
+# 둘 다 상한도 evict 도 없다. 인덱스는 한 번 읽고 마니 상수지만, 전문(全文)은 조회한 법령
+# 파일이 계속 쌓인다 — 코퍼스가 유한해서 언젠가 멈추긴 하지만 그 천장이 얼마인지 아무도
+# 모른다. 관측 장부에 올려 둔다(정의한 자리에서 등록해야 캐시를 더할 때 안 빠뜨린다).
+_register_unbudgeted_cache("law_fulltext", lambda: _FULLTEXT_CACHE)
+_register_unbudgeted_cache("law_index", lambda: _INDEX_CACHE)
 
 
 def load_index() -> dict[str, Any]:

--- a/open_proxy_mcp/services/trading.py
+++ b/open_proxy_mcp/services/trading.py
@@ -21,6 +21,8 @@ import asyncio
 import os
 from typing import Any
 
+from open_proxy_mcp.dart.client import register_unbudgeted_cache as _register_unbudgeted_cache
+
 from open_proxy_mcp.market_codes import to_label as mkt_label
 from open_proxy_mcp.services.price_multiple_data import (
     _DB_ERROR_PAYLOAD_WARN,
@@ -44,6 +46,10 @@ _SCHEMES = {
 #: 남의 캐시를 오염시키지 않으려고 작은 장부를 따로 둔다(행 하나 ≈ 400B, 512행 ≈ 200KB).
 _QUOTE_CACHE: dict[tuple[str, str], dict] = {}
 _QUOTE_CACHE_MAX = 512
+
+# 상한이 있는 쪽도 올린다 — **대조군**이다. 예산 없는 캐시가 자랄 때 이쪽이 평평하면
+# 「자라는 건 상한 없는 것들」이 눈으로 갈린다. 하나만 보면 그 판정을 못 한다.
+_register_unbudgeted_cache("trading_quote", lambda: _QUOTE_CACHE)
 
 
 #: 시계열 해상도. 저장분은 **주간**이라 `weekly` 가 원본이고 `monthly` 는 월말 다운샘플이다.

--- a/tests/test_unbudgeted_cache_observability.py
+++ b/tests/test_unbudgeted_cache_observability.py
@@ -1,0 +1,87 @@
+"""예산 없는 전역 캐시가 **보이는지** — 관측 계약. 네트워크 0.
+
+배경(260901·260909). 260901 에 두 머신이 동시에 OOM(exit 137) 했을 때 `/health` 의 캐시
+점유는 예산 296MB 의 33% 였다 — 「멀쩡하다」로 읽힌다. 260909 에도 같은 모양이 났다:
+부팅 직후 242MB 인 프로세스가 30분 만에 708MB 가 되고 2~3시간마다 죽는데,
+`cache_stats()` 는 내내 `_used_mb: 0.0` 을 보고했다.
+
+즉 **자라는 것이 관측 밖에 있었다.** `_CACHE_REGISTRY` 는 `LruByteCache` 전용이라
+서비스가 모듈 전역에 둔 평범한 dict 캐시(상한도 evict 도 없는 것들)를 못 본다.
+이 테스트는 그 장부가 실제로 그것들을 잡는지 못 박는다.
+"""
+import pytest
+
+from open_proxy_mcp.dart import client as C
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """장부는 모듈 전역이라 테스트끼리 샌다 — 앞뒤로 갈아 끼운다."""
+    saved, saved_memo = list(C._UNBUDGETED_CACHES), dict(C._unbudgeted_memo)
+    C._UNBUDGETED_CACHES.clear(); C._unbudgeted_memo.clear()
+    yield
+    C._UNBUDGETED_CACHES[:] = saved
+    C._unbudgeted_memo.clear(); C._unbudgeted_memo.update(saved_memo)
+
+
+def test_a_registered_cache_shows_its_size():
+    cache = {f"k{i}": "x" * 1000 for i in range(50)}
+    C.register_unbudgeted_cache("t", lambda: cache)
+    st = C.unbudgeted_cache_stats()
+    assert st["t"]["entries"] == 50
+    assert st["t"]["bytes_est"] > 40_000        # 50 × ~1KB
+    assert st["_total_mb"] >= 0
+
+
+def test_the_getter_follows_rebinding():
+    """설계의 핵심 — dict 를 직접 받으면 `_X = None` 으로 시작하는 캐시를 영영 0 으로 본다.
+
+    `law_index` 가 정확히 그 모양이라(로드 전 None → 로드 시 새 dict 로 재바인딩),
+    직접 참조였다면 54MB 를 0 으로 보고했을 것이다.
+    """
+    box = {"v": None}
+    C.register_unbudgeted_cache("late", lambda: box["v"])
+    assert C.unbudgeted_cache_stats()["late"]["entries"] == 0
+
+    box["v"] = {f"k{i}": "y" * 500 for i in range(10)}
+    st = C.unbudgeted_cache_stats()
+    assert st["late"]["entries"] == 10 and st["late"]["bytes_est"] > 0
+
+
+def test_growth_is_visible_without_waiting_for_the_ttl():
+    """개수가 바뀌면 즉시 다시 잰다 — 60초 memo 가 **자라는 것을 가리면** 계기가 무의미하다."""
+    cache: dict[str, str] = {}
+    C.register_unbudgeted_cache("g", lambda: cache)
+    first = C.unbudgeted_cache_stats()["g"]["bytes_est"]
+    cache.update({f"k{i}": "z" * 2000 for i in range(100)})
+    assert C.unbudgeted_cache_stats()["g"]["bytes_est"] > first
+
+
+def test_a_broken_getter_does_not_break_the_health_check():
+    """관측이 서빙을 깨면 안 된다 — 하나가 죽어도 나머지는 나온다."""
+    def _boom():
+        raise RuntimeError("등록된 캐시가 사라졌다")
+
+    C.register_unbudgeted_cache("bad", _boom)
+    C.register_unbudgeted_cache("good", lambda: {"a": 1})
+    st = C.unbudgeted_cache_stats()
+    assert "bad" not in st and st["good"]["entries"] == 1
+
+
+def test_registering_the_same_name_twice_keeps_one():
+    """모듈이 두 번 import 돼도 장부가 부풀지 않는다."""
+    C.register_unbudgeted_cache("dup", lambda: {"a": 1})
+    C.register_unbudgeted_cache("dup", lambda: {"a": 1, "b": 2})
+    assert sum(1 for n, _ in C._UNBUDGETED_CACHES if n == "dup") == 1
+
+
+def test_the_real_caches_are_registered_at_their_definition_site(_isolate_registry=None):
+    """나열식이면 캐시를 더할 때 한쪽만 고쳐진다(260824 교훈) — 정의한 자리에서 등록한다."""
+    C._UNBUDGETED_CACHES[:] = []
+    import importlib
+    for mod in ("open_proxy_mcp.services.financial_metrics",
+                "open_proxy_mcp.services.law_lookup",
+                "open_proxy_mcp.services.trading"):
+        importlib.reload(importlib.import_module(mod))
+    names = {n for n, _ in C._UNBUDGETED_CACHES}
+    assert {"financial_metrics", "law_fulltext", "law_index", "trading_quote"} <= names

--- a/wiki/decisions/mcp-endpoints.md
+++ b/wiki/decisions/mcp-endpoints.md
@@ -1,7 +1,7 @@
 ---
 type: architecture
 title: MCP 엔드포인트 — live-opm / pilot-opm 두 개, 목적이 다르고 따로 관리한다
-updated: 2026-08-02
+updated: 2026-09-09
 ---
 
 # MCP 엔드포인트 — live-opm / pilot-opm
@@ -194,6 +194,33 @@ FLY=~/.fly/bin/flyctl
 - **호출시간 로그**: 모든 tool 호출이 `opm.tool` 로거에 `tool=… wall=… cpu=… args=[인자이름]` 한 줄을 남긴다(값은 남기지 않는다 — 규칙 10). `OPM_SLOW_TOOL_SEC`(기본 10초)를 넘으면 WARNING `slow tool=…`. 벽시계≈CPU 면 동기 파싱이 이벤트 루프를 잡은 것, 벽시계≫CPU 면 I/O 대기. `OPM_TOOL_LOG=0` 이면 느린 호출만 남긴다.
 - **스택 덤프**: `faulthandler` 가 SIGUSR1 에 등록돼 있다. 머신이 CPU 를 붙들고 `/health` 에 답을 못 하면 `fly ssh console -a open-proxy-mcp --machine <id> -C "kill -USR1 1"` 이 아니라 **파이썬 pid** 에 보낸다(`/proc` 에서 `open_proxy_mcp.server` 를 찾는다; 컨테이너 CMD 는 python 직접 실행이라 보통 pid 는 작다). 모든 스레드의 스택이 stderr(=`fly logs`)에 찍히고 프로세스는 계속 돈다. 로컬 pilot 은 `uv run` 이 부모라 **python 자식 pid** 에 보내야 한다 — 부모에 보내면 죽는다.
 - **왜**: 260907 머신 하나가 R 상태·load 1.0 으로 5분 넘게 헬스에 답을 못 했는데(메모리 여유), 로그는 최근 100줄만 남고 스택을 볼 수단이 없어 원인을 못 잡았다. 200케이스 재현에서도 재발하지 않았다. 이 둘은 다음 번을 진단 가능하게 만드는 최소 장치다. 헬스체크 timeout 은 15초라 그 이상 루프를 잡는 호출은 그 머신을 critical 로 만든다.
+
+## 운영 진단 — 메모리 (260909)
+
+`/health` 의 `cache` 는 **예산이 있는 캐시**(`LruByteCache`)만 센다. 예산 없는 모듈 전역 dict
+캐시는 거기 안 잡히고, 260901·260909 OOM 이 둘 다 그 사각에서 났다 — 260909 실측으로
+부팅 직후 **242MB** 인 프로세스가 30분 만에 **708MB** 가 되고 2~3시간마다 exit 137 로 죽는
+동안, `cache._used_mb` 는 내내 **0.0** 이었다.
+
+그래서 세 자를 함께 본다:
+
+| 절 | 무엇을 답하나 |
+|---|---|
+| `cache` | 예산 있는 캐시가 예산 대비 얼마나 찼나 |
+| `unbudgeted_cache` | 예산 **없는** 전역 dict 가 얼마나 자랐나 (`_total_mb`) |
+| `runtime` | 캐시가 아닌 증가 — 태스크·스레드 누수, 회수 못 한 순환(`gc_garbage`) |
+
+- 등록은 **캐시를 정의한 자리**에서 한다(`register_unbudgeted_cache(name, getter)`).
+  나열식으로 모으면 캐시를 더할 때 한쪽만 고쳐진다 — 260824 에 실제로 184MB 가 관측 밖에 있었다.
+- `getter` 는 dict 가 아니라 **호출 가능한 것**을 받는다. `_X_CACHE = None` 으로 시작해 나중에
+  재바인딩되는 캐시(`law_index` 가 그렇다)를 직접 참조로 잡으면 영영 0 을 보고한다.
+- 바이트는 표본 추정 + 60초 memo 다. 전수 재귀는 헬스체크를 수백 ms 로 만들고, **재는 행위가
+  재려는 대상을 흔든다.** 개수가 바뀌면 memo 를 무시하고 다시 잰다 — 그러지 않으면 계기가
+  자라는 것을 가린다.
+- 상한 있는 `trading_quote` 를 **대조군**으로 같이 싣는다. 하나만 보면 「자라는 게 상한 없는
+  것들」이라는 판정을 못 한다.
+- `mem` 의 `cg_*`(cgroup)는 커널이 한도와 견주는 자인데 **fly 컨테이너에서 안 읽힌다**(260909 확인).
+  지금 OOM 을 예측할 수 있는 건 `rss_mb` 뿐이다.
 
 ## 관련
 


### PR DESCRIPTION
## 왜

오늘(260909) live 에서 실제로 OOM 이 났다. 두 머신 중 하나가 **13:33 KST 에 exit 137 · `oom_killed: true`** 로 죽고 재시작했다. swap 은 없어서 한도에 닿는 순간 유예 없이 SIGKILL 이다.

측정해 보니 「기저 메모리가 높다」가 아니라 **시간에 비례해 자란다**:

| 머신 나이 | RSS |
|---|---|
| 0.1h (갓 부팅) | **242MB** |
| 0.5h | **708MB** |

분당 약 4MB. 242MB → 1024MB 가 약 3시간이고, 실제로 죽은 머신은 **2시간 38분** 살았다.

**그런데 그동안 `/health` 의 `cache._used_mb` 는 내내 `0.0` 이었다.** 예산 296MB 중 한 바이트도 안 썼다고 보고하는 중에 프로세스는 466MB 가 늘었다. 260901 에도 똑같았다(두 머신 동시 OOM, 캐시 점유 33%, 실사용 950MB). 그때 `cache_clear` 를 레버로 달았지만 **무엇이 자라는지는 여전히 못 봤다.**

원인은 관측의 구멍이다. `_CACHE_REGISTRY` 는 `LruByteCache` 전용이라, 서비스가 모듈 전역에 둔 평범한 dict 캐시 — 상한도 evict 도 없는 것들 — 를 **애초에 세지 않는다.**

## 무엇을

세 자를 함께 본다:

| 절 | 답하는 질문 |
|---|---|
| `cache` (기존) | 예산 있는 캐시가 예산 대비 얼마나 찼나 |
| `unbudgeted_cache` (신규) | 예산 **없는** 전역 dict 가 얼마나 자랐나 |
| `runtime` (신규) | 캐시가 아닌 증가 — 태스크·스레드 누수, 회수 못 한 순환 |

붙이자마자 하나 나왔다 — **`law_index` 54.7MB.** 지금까지 어디에도 안 보이던 값이다.

```
cache            _used_mb = 0.0     ← 기존이 보던 것
unbudgeted_cache _total_mb = 54.7   ← 새로 보이는 것
```

## 설계에서 갈린 자리 셋

- **등록은 캐시를 정의한 자리에서.** 나열식으로 모으면 캐시를 더할 때 한쪽만 고쳐진다 — 260824 에 실제로 184MB 가 관측 밖에 있었고, 그게 `cache_stats` 를 장부 순회로 바꾼 이유다. 같은 교훈을 그대로 적용했다.
- **`getter` 는 dict 가 아니라 호출 가능한 것.** `_X_CACHE = None` 으로 시작해 나중에 재바인딩되는 캐시를 직접 참조로 잡으면 영영 0 을 보고한다. `law_index` 가 정확히 그 모양이라, 직접 참조였다면 54.7MB 를 0 으로 봤을 것이다. 테스트로 고정했다.
- **재는 행위가 재려는 대상을 흔들면 안 된다.** 바이트는 표본 20개 + 60초 memo 다(전수 재귀는 헬스 한 번을 수백 ms 로 만든다). 단 **개수가 바뀌면 memo 를 무시**한다 — 아니면 계기가 자라는 것을 가린다.

상한 있는 `trading_quote` 를 **대조군**으로 함께 싣는다. 하나만 보면 「자라는 건 상한 없는 것들」이라는 판정 자체를 못 한다.

## 아직 고치지 않은 것

`_FM_CACHE`(`financial_metrics.py:2526`)가 유력하다 — TTL 이 **읽을 때만** 걸려서 쓰고 다시 안 읽히는 키는 영영 안 지워지고, 값이 통짜 페이로드다. 옆의 `_QUOTE_CACHE` 는 같은 모양인데 `_QUOTE_CACHE_MAX = 512` 로 막혀 있다.

**그래도 이번엔 안 고쳤다.** 이건 코드를 읽고 찾은 것이지 잰 게 아니다. 며칠 계기를 보고 실제로 자라는 게 확인되면 상한이나 sweep 을 단다 — 재기 전에 값을 고르지 않는다.

## 검증

- `pytest -q` **1,727 passed** (신규 6 — 재바인딩 추적 · 개수 변화 시 즉시 재측정 · 깨진 getter 가 헬스를 안 죽임 · 중복 등록 · 정의 자리 등록 확인)
- `wiki_lint --strict` · `check_tool_catalog` · `output_vocab_lint` 통과
- pilot `/health` 실호출로 세 절 모두 확인

## 남은 위험 (이 PR 범위 밖)

`mem` 의 `cg_*`(cgroup)는 커널이 한도와 견주는 자인데 **fly 컨테이너에서 안 읽힌다.** 지금 OOM 을 예측할 수 있는 건 `rss_mb` 뿐이다. 그리고 원인을 찾을 때까지 live 는 계속 2~3시간마다 죽는다 — `fly scale memory 2048` 은 별도 판단이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)