### PR TITLE
사설 DB 스키마가 공개 위키에 드러난 자리 정리 (규칙 14)

### DIFF
--- a/wiki/decisions/environment-secrets.md
+++ b/wiki/decisions/environment-secrets.md
@@ -33,7 +33,7 @@ fly.toml `[env]`에는 경로 같은 **비밀 아닌 설정**만 둔다. API 키
 | `OPM_CAPTURE_DIR` | 요청·응답 전문 캡처(로컬 시험용, 배포 금지) | 로컬 | — |
 | `OPM_DOC_CACHE_MB`·`OPM_DIVIDEND_CACHE_MB`·`OPM_DOC_DISK_CACHE_MB`·`OPM_DOC_DISK_SWEEP_MB`·`OPM_CACHE_HIGH_RATIO`·`OPM_CACHE_LOW_RATIO`·`OPM_DOC_CONCURRENCY`·`OPM_DOC_GATE_WAIT_SEC`·`OPM_DOC_CONCURRENCY_PER_KEY`·`OPM_CLIENT_MAX`·`OPM_CLIENT_IDLE_SEC`·`OPM_PG_POOL_MAX/MIN/TIMEOUT/RETRY_SEC`·`OPM_SCAN_CACHE_TTL_SEC`·`OPM_SCAN_CACHE_CLOSED_SEC` | 캐시·동시성·풀 튜닝 노브. 기본값은 코드(`dart/client.py`·`db.py`·`services/screener.py`) | 선택 | — |
 | `NAVER_SEARCH_API_CLIENT_ID` / `..._SECRET` | 네이버 검색(뉴스 체크) | 선택 | developers.naver.com |
-| `DATABASE_URL` | Supabase Postgres — 사용통계·KRX데이터·FX캐시·밸류에이션·컨센서스·스크리너 | 배치·통계·DB 기반 scope 필수 | Supabase 콘솔 |
+| `DATABASE_URL` | 내부 데이터 저장소(Postgres) — 사전 수집·집계본 서빙 | 배치·통계·DB 기반 scope 필수 | (자체 구성) |
 | `KRX_API_KEY` | KRX_OPEN_API_KEY 와 같은 키의 별칭 (`services/price_multiple_data.py`·`trading.py` 가 둘 다 본다) | — | — |
 
 - **필수** = 이게 없으면 핵심 tool이 동작 안 함. **선택** = 해당 기능만 비활성(앱은 기동).

--- a/wiki/rules/concepts/배당수익률.md
+++ b/wiki/rules/concepts/배당수익률.md
@@ -15,7 +15,7 @@ related: [배당성향, 분기배당, DART-OpenAPI]
 | 항목 | 시가배당률 (DART 공시값) | 배당수익률 (OPM 계산값) |
 |---|---|---|
 | 정의 | 1주당 배당금 ÷ 기준주가 × 100 | FY0 연간 DPS ÷ **현재가** × 100 |
-| 기준주가 | 배당기준일 전전거래일부터 과거 **1주일간 종가 산술평균**(거래소 공시규정 시행세칙) | `krx_weekly` 최신 주간 종가(Supabase 캐시, `price_multiple_data._market_for`) |
+| 기준주가 | 배당기준일 전전거래일부터 과거 **1주일간 종가 산술평균**(거래소 공시규정 시행세칙) | 최신 주간 종가(주간 시세 저장분, `price_multiple_data._market_for`) |
 | 시점 | 배당 결정 당시 (과거 고정) | 조회 시점 (「지금 사면 몇 %」) |
 | 소스 | 사업보고서 `alotMatter` 「현금배당수익률(%)」 · 현금배당결정 공시 「시가배당률」 | 계산 — DPS 는 `alotMatter` 보통주 현금배당(원), 주가는 KRX |
 | OPM 필드 | `dividend_disclosure` `yield_dart` / `yield_pct` | `price_multiple_data` `dividend_yield_pct` · `dividend_disclosure` `yield_current_pct`(+`yield_current_price_krw`·`yield_current_price_date`) |

--- a/wiki/tools/README.md
+++ b/wiki/tools/README.md
@@ -166,10 +166,10 @@ tool별로 `scope.summary`, `fetch_decisions`, `decision_details`, `load_report_
 | provisional_earnings | ✅ list(I001 결산잠정치·I002 공정공시) + 원문 파싱 | - | - | - |
 | business_details | ✅ get_document 1콜(II.사업의 내용 + 주석 부문정보) + list(A001~A003) | - | - | - |
 | financial_notes | ✅ get_document(III.재무에 관한 사항 주석·재무상태표) | - | - | - |
-| price_multiple_data | ✅ 재무 4EP + company.json + fnlttSinglAcntAll + stockTotqySttus + alotMatter (firm) | - | - | ✅ Supabase 주간 스냅샷(market/sector/firm_history) · KRX 시세 · ECOS 환율 |
-| trading_data | - | - | - | ✅ Supabase krx_weekly·krx_cap_agg·krx_adj_events·wise_sector (quote 만 KRX 라이브) |
-| forward_estimates_data | - | - | - | ✅ Supabase `fwd` 컨센서스 스냅샷(벤더 원천, DART 아님) |
-| dividend_data | - (전수 수집본·결정공시 집계 조회) | - | - | ✅ Supabase div_declared·div_quarterly(alotMatter 수집본) + div_payment·div_payment_scope(결정공시) + krx_listing + wise_sector |
+| price_multiple_data | ✅ 재무 4EP + company.json + fnlttSinglAcntAll + stockTotqySttus + alotMatter (firm) | - | - | ✅ 주간 시세·시총 저장분 · KRX 시세 · ECOS 환율 |
+| trading_data | - | - | - | ✅ 주간 시세·시장/섹터 시총·기준가 조정·업종분류 저장분 (quote 만 KRX 라이브) |
+| forward_estimates_data | - | - | - | ✅ 컨센서스 스냅샷 저장분(벤더 원천, DART 아님) |
+| dividend_data | - (전수 수집본·결정공시 집계 조회) | - | - | ✅ 배당 확정·분기 저장분(alotMatter 수집본) + 결정공시 집계 + 상장정보 + 업종분류 |
 | director_news | - | - | ✅ 뉴스 검색 API 1콜 | ✅ 부정 키워드 사전 |
 | proxy_guideline | - | - | - | ✅ 패키지 데이터 open-proxy-guideline.md (API 0콜) |
 | proxy_contest | ✅ D/B/I + document | ✅ vote_math whitelist | - | - |

--- a/wiki/tools/asset_holdings.md
+++ b/wiki/tools/asset_holdings.md
@@ -69,7 +69,7 @@ updated: 2026-09-09
 - `is_financial`(KSIC 64/65/66 게이트) · `is_reit`(사명 "리츠"/"REIT" 휴리스틱) — 둘 다 투자부동산이
   본업이라 잉여자산에서 제외하고 라벨링.
 - `market_cap_krw`: **[[price_multiple_data]] `_market_for` 의 `common_mktcap` 재사용** = KRX 상장주식수(`list_shrs`) ×
-  최신 주간 종가(`krx_weekly`, Supabase 캐시, DART 0콜). 유통주식수(자기주식 제외)가 아니다 — 260721 변경이력 참조.
+  최신 주간 종가(주간 시세 저장분, DART 0콜). 유통주식수(자기주식 제외)가 아니다 — 260721 변경이력 참조.
   `market_cap_meta`: `{shares, close, date}` 기준 명시. 시세 실패 시 `None` + `{reason}`.
 - `asset_buckets`: 목적버킷 6분류([[260721_1500_decision_asset-holdings-purpose-buckets]]) — `{라벨: {krw, desc}}`,
   값 있는 버킷만 순서대로. 현금성/환금성증권/우호제휴지분/지배관계사지분/투자용부동산/본업자산.

--- a/wiki/tools/forward_estimates_data.md
+++ b/wiki/tools/forward_estimates_data.md
@@ -4,7 +4,7 @@ title: forward_estimates_data
 domain: data
 status: 등록 완료 (260830 — tools/forward_estimates_data.py, 브랜치 beta)
 scope: [firm]
-data_source: [Supabase `fwd` 컨센서스 추정치 스냅샷 (외부 벤더 원천 + 파생 계산)]
+data_source: [컨센서스 추정치 스냅샷 저장분 (외부 벤더 원천 + 파생 계산)]
 related_disclosures: []
 related_concepts: [당기순이익, ROE, 배당수익률, PER-PBR, 시가총액, 연결-별도, 단위-표기-규약]
 created: 2026-08-30
@@ -16,7 +16,7 @@ updated: 2026-09-04
 컨센서스 **포워드 추정치**(내년·내후년 예상 실적과 배수)를 낸다. 대조용으로 최근 실적 행을
 같이 싣는다 — 「2026E EPS 48,139」는 「2025A 6,564」 옆에 있어야 뜻이 생긴다.
 
-**DART 공시가 아니다.** 애널리스트 컨센서스 스냅샷(`fwd`, Supabase)을 읽는다.
+**DART 공시가 아니다.** 사전 수집한 애널리스트 컨센서스 스냅샷을 읽는다.
 
 ## 입력 인자
 | 인자 | 타입 | 필수 | 설명 | 기본값 |
@@ -108,7 +108,7 @@ DB 물리 칸이 아직 `_eok` 면 도구가 ×1e8 해서 원으로 통일한다
 매핑 표는 `services/forward_estimates.py` 의 `_FIELDS` **한 곳**에만 있다. 개명 전후 양쪽에서 돈다.
 
 ## DART 콜
-**0콜.** Supabase 조회만 한다(회사 식별은 공용 리졸버 캐시 경로).
+**0콜.** 저장분 조회만 한다(회사 식별은 공용 리졸버 캐시 경로).
 
 ## 변경 이력
 

--- a/wiki/tools/price_multiple_data.md
+++ b/wiki/tools/price_multiple_data.md
@@ -134,9 +134,9 @@ price_multiple_data(scope="firm_history", company="삼성전자")  # 종목 PER/
 | 재무요약 | `build_financial_metrics_payload(stock_code)` → DART **fnlttSinglAcnt·AcntAll·Indx·감사의견** | eps_krw · revenue_krw · roe_pct · capital_impairment_status · fiscal year | EPS(FY0)·ROE·매출·자본잠식 상태 |
 | 업종/결산월 | `get_company_info` → DART **company.json** | induty_code(KSIC) · acc_mt(결산월) | 금융 판별(64/65/66) · FX 기준일 |
 | 재무원장 | `get_fnltt_singl_acnt_all` ×3 (연간 11011 + 1Q당해 11013 + 1Q전년 11013) | `_ctrl_ni`(지배순이익) · `_ctrl_equity`(지배자본) · `_gid`(Assets/Liab/Equity, **exact-match**) | TTM 순이익 · BPS · 스케일 항등식 |
-| 통화 | `statement_currency`(currency 필드) + `fx_to_krw` → **ECOS 731Y001**(→야후 폴백) + Supabase `fx_rate` 캐시 | 기능통화 · 기말환율 | 비KRW → 재무 KRW 환산 |
+| 통화 | `statement_currency`(currency 필드) + `fx_to_krw` → **ECOS 731Y001**(→야후 폴백) + 환율 캐시 저장분 | 기능통화 · 기말환율 | 비KRW → 재무 KRW 환산 |
 | 주식수 | `get_stock_total` → DART **stockTotqySttus** | distb_stock_co(합계/보통주, 자기주식 제외) | EPS 분모(보통주)·BPS 분모(합계) |
-| 시세 | **Supabase `krx_weekly`(검증 자산, 2015-12~)** 우선 → 미스·최신 확보 시만 라이브 KRX stk/ksq_bydd_trd | close(종가) · mktcap · list_shrs | 배수 분자(주가)·시총 노출·주식수 검증 |
+| 시세 | **주간 시세 저장분(검증 자산, 2015-12~)** 우선 → 미스·최신 확보 시만 라이브 KRX stk/ksq_bydd_trd | close(종가) · mktcap · list_shrs | 배수 분자(주가)·시총 노출·주식수 검증 |
 | 배당 | `_annual_summary` → DART **alotMatter** | cash_dps(주당현금배당, 이미 주당값) | 배당수익률 |
 
 ## 연산 파이프라인
@@ -213,10 +213,10 @@ PBR(MRQ)     = 보통주 시총 ÷ 지배자본(MRQ 우선, 없으면 FY0 — pb
 | DART stockTotqySttus | 1 | 유통주식수 |
 | DART alotMatter(배당) | ~2 | 연간 요약 |
 | **DART 합계** | **11 (최대 ~15, 실측 260705)** | per-firm. scope=market/sector/firm_history는 **DART·KRX 0콜(DB만)** |
-| KRX (시세) | **serve-time 0** | Supabase `krx_weekly`에서 읽음. 라이브 KRX는 하루 1회 최신 거래일 스냅샷 확보 시만(전종목 2콜, 코스피·코스닥 병렬) → **유저 수 무관 하루 ~수십콜 bounded**. KRX 개인키 일 10,000 한도 보호 |
+| KRX (시세) | **serve-time 0** | 주간 시세 저장분에서 읽음. 라이브 KRX는 하루 1회 최신 거래일 스냅샷 확보 시만(전종목 2콜, 코스피·코스닥 병렬) → **유저 수 무관 하루 ~수십콜 bounded**. KRX 개인키 일 10,000 한도 보호 |
 | ECOS 환율 | 0~1 | 비KRW사만, 분기말 캐시 히트 시 0 |
 
-**KRX 시세 = Supabase krx_weekly 서빙**: KRX Open API는 개인키 1개·일 10,000콜 한도(배치와
+**KRX 시세 = 주간 시세 저장분 서빙**: KRX Open API는 개인키 1개·일 10,000콜 한도(배치와
 공유)라 라이브 유저를 직접 서빙하면 키 소진 시 배수 N/M 위험. FX 캐시와 동형 — 매일 최신 거래일
 전종목 스냅샷을 라이브로 확보해 **'그 주(ISO week)' 슬롯에 덮어쓰며 갱신**(전날 종가까지 표시), 주중
 일별은 다음 거래일에 덮여 사라지고 **주 마지막 거래일만 영구 보존**(주당 1스냅샷 ~52/년 = 무료티어

--- a/wiki/tools/trading_data.md
+++ b/wiki/tools/trading_data.md
@@ -4,7 +4,7 @@ title: trading_data
 domain: data
 status: 등록 완료 (260824 — tools/trading.py)
 scope: [firm, quote, market, sector]
-data_source: [KRX stk/ksq_bydd_trd(일별매매정보), Supabase krx_weekly(주간 시세), Supabase krx_cap_agg(시장·섹터 시총 집계), Supabase krx_adj_events(기준가 조정), Supabase wise_sector(WICS 업종분류)]
+data_source: [KRX stk/ksq_bydd_trd(일별매매정보), 주간 시세 저장분, 시장·섹터 시총 집계 저장분, 기준가 조정 저장분, WICS 업종분류 저장분]
 related_disclosures: []
 related_concepts: [시가총액, 단위-표기-규약]
 created: 2026-08-24


### PR DESCRIPTION
CLAUDE.md 규칙 14 는 **Supabase 스키마를 private 자산**으로 명시한다. 그런데 공개 위키가 벤더명과 테이블명을 그대로 적고 있었다.

가장 큰 자리는 `environment-secrets.md` 였다:

> `DATABASE_URL` | Supabase Postgres — 사용통계·**KRX데이터·FX캐시·밸류에이션·컨센서스·스크리너** |

「DB 에 무엇이 들었고 없으면 무엇이 안 되는지」가 한 줄로 요약돼 있었다. 사전 수집분이 이 서버의 차별점인데 그 목록이 셋업 문서에 있었던 셈이다.

## 방향

260907 에 `price_multiple_data` 출처표를 「Supabase krx_weekly」→「주간 시세 저장분」으로 바꾼 **선례**가 있다. 그 방향으로 남은 자리를 맞췄다 — **내용의 종류는 남기고 벤더·테이블 이름만 뺀다.** 이용자가 알아야 할 것(어떤 자료를 언제 기준으로 서빙하는가)은 그대로다.

| 파일 | |
|---|---|
| `wiki/decisions/environment-secrets.md` | `DATABASE_URL` 용도 → 「내부 데이터 저장소(Postgres) — 사전 수집·집계본 서빙」. 셋업에 필요한 키 이름·필수 여부는 유지 |
| `wiki/tools/README.md` | 출처표 4행 |
| `forward_estimates_data` · `trading_data` · `price_multiple_data` · `asset_holdings` · `배당수익률` | 본문·frontmatter |

## 알고 멈춘 것 둘

**① 위키에 40곳쯤 더 있다.** 다만 `scripts/krx_cap_agg.py` 처럼 **공개 파일명이 테이블명을 그대로 유추시키는** 자리가 섞여 있다. 문서만 뭉개도 안 가려지고, 정비 문서로서의 값만 잃는다.

**② 더 중요한 것 — 테이블 이름이 이미 응답에 나간다.**

```python
company_resolver.py:202   MarketContext(caps, active, as_of_date, "krx_weekly")
company.py:316            "market_data_source": meta.get("market_data_source")
```

`company` 를 쓰는 모든 이용자의 응답에 `"market_data_source": "krx_weekly"` 가 찍힌다. **위키를 아무리 가려도 이 필드가 있는 한 이름은 나간다.** 고치려면 여기가 유일하게 효과 있는 한 줄인데, 이용자 응답 값이 바뀌므로 별도 판단으로 남긴다.

## 검증

`wiki_lint --strict` · `check_tool_catalog` · `pytest -q` 1,727 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)