### PR TITLE
CI: setup-uv 에 uv 버전 고정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.12.13"  # 260909 CI 실패 방지 — 정확한 버전은 버전 목록 조회를 건너뛴다. 올릴 때 9개 워크플로 함께
       - name: Install dependencies
         run: uv sync --dev
       - name: Check tool catalog

--- a/.github/workflows/drain-backlog-weekly.yml
+++ b/.github/workflows/drain-backlog-weekly.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.12.13"  # 260909 CI 실패 방지 — 정확한 버전은 버전 목록 조회를 건너뛴다. 올릴 때 9개 워크플로 함께
 
       - name: Sync deps
         run: uv sync

--- a/.github/workflows/finstat-quarterly.yml
+++ b/.github/workflows/finstat-quarterly.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.12.13"  # 260909 CI 실패 방지 — 정확한 버전은 버전 목록 조회를 건너뛴다. 올릴 때 9개 워크플로 함께
 
       - name: Sync deps
         run: uv sync

--- a/.github/workflows/law-corpus-weekly.yml
+++ b/.github/workflows/law-corpus-weekly.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.12.13"  # 260909 CI 실패 방지 — 정확한 버전은 버전 목록 조회를 건너뛴다. 올릴 때 9개 워크플로 함께
 
       - name: Sync deps
         run: uv sync

--- a/.github/workflows/market-val-weekly.yml
+++ b/.github/workflows/market-val-weekly.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.12.13"  # 260909 CI 실패 방지 — 정확한 버전은 버전 목록 조회를 건너뛴다. 올릴 때 9개 워크플로 함께
 
       - name: Sync deps
         run: uv sync

--- a/.github/workflows/periodic-filers-monthly.yml
+++ b/.github/workflows/periodic-filers-monthly.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.12.13"  # 260909 CI 실패 방지 — 정확한 버전은 버전 목록 조회를 건너뛴다. 올릴 때 9개 워크플로 함께
 
       - name: Sync deps
         run: uv sync

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.12.13"  # 260909 CI 실패 방지 — 정확한 버전은 버전 목록 조회를 건너뛴다. 올릴 때 9개 워크플로 함께
       - name: Install dependencies
         run: uv sync --dev
       - name: Check tool catalog

--- a/.github/workflows/wics-monthly.yml
+++ b/.github/workflows/wics-monthly.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.12.13"  # 260909 CI 실패 방지 — 정확한 버전은 버전 목록 조회를 건너뛴다. 올릴 때 9개 워크플로 함께
 
       - name: Sync deps
         run: uv sync

--- a/.github/workflows/wiki-lint.yml
+++ b/.github/workflows/wiki-lint.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.12.13"  # 260909 CI 실패 방지 — 정확한 버전은 버전 목록 조회를 건너뛴다. 올릴 때 9개 워크플로 함께
       - name: Install dependencies
         run: uv sync --dev
       - name: Verify wiki_index counts are generated (not hand-drifted)


### PR DESCRIPTION
9월 9일 main 푸시에서 Wiki Link Policy Lint 가 잡 시작 9초 만에 죽은 건의 재발 방지입니다. 원인은 이 레포 코드가 아니라 액션이 「어떤 uv 를 깔지」를 인터넷에 물어본 것이었습니다.

```
Could not determine uv version from uv.toml or pyproject.toml. Falling back to latest.
Fetching version data from .../astral-sh/versions/main/v1/uv.ndjson ...
##[error]fetch failed
```

## 왜 이 한 줄이 고치나

액션 소스에서 확인했습니다. 정확한 버전을 주면 **그 조회가 아예 일어나지 않습니다.**

| 액션 | 정확한 버전일 때 |
|---|---|
| v7 | `ExactVersionResolver` 가 값을 그대로 반환하고 종료 |
| v5 | `tc.isExplicitVersion` 분기에서 그대로 반환하고 종료 |

네트워크를 타는 것은 `latest` 와 범위 지정뿐입니다. 게다가 해석된 버전이 고정되면 러너의 tool-cache 를 맞힐 수 있어, 맞으면 내려받기조차 없습니다.

`0.12.13` 은 현재 최신이고 CI 가 `latest` 로 이미 받아 쓰던 그 버전입니다. **동작은 그대로입니다.**

## 바꾼 곳

9개 워크플로에 같은 두 줄. v5 5개와 v7 4개 모두 `version` 입력을 지원합니다.

`deploy` · `test` · `wiki-lint` · `drain-backlog-weekly` · `finstat-quarterly` · `law-corpus-weekly` · `market-val-weekly` · `periodic-filers-monthly` · `wics-monthly`

## 안 한 것 둘

- **`pyproject.toml` 의 `[tool.uv] required-version`** 이면 한 곳으로 끝나지만, 그것은 **로컬 uv 버전까지 강제**해서 버전이 다른 기계에서 `uv run` 이 막힙니다. 게다가 v5 는 그 필드를 읽지 않아 크론 5개는 어차피 안 고쳐집니다.
- **`setup-uv` 의 v5/v7 분열**은 그대로 뒀습니다. 메이저 올리기는 별건이고, 크론 잡은 PR 에서 돌려볼 수 없어 여기서 함께 바꾸지 않았습니다.

## 검사

워크플로 9개 YAML 파싱과 각 `setup-uv` 스텝의 `with.version` 존재를 확인했습니다. 9/9 통과.

**미검증 범위를 밝힙니다.** 크론 5개는 PR 에서 실행되지 않으므로 다음 예약 실행 전까지 확인되지 않습니다. 변경은 `deploy`·`test`·`wiki-lint` 와 문자 그대로 같은 한 줄이고, 그 셋은 이 PR 에서 돌아갑니다.

## 앞으로

버전이 박혔으니 올릴 때는 9개를 함께 올려야 합니다. 각 줄에 그 취지를 주석으로 달아 뒀습니다. Dependabot 의 `github-actions` 생태계 설정을 두면 자동으로 올라옵니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tX9Aa9zuF3cM5BwAhSwU6

---
_Generated by [Claude Code](https://claude.ai/code/session_017tX9Aa9zuF3cM5BwAhSwU6)_